### PR TITLE
feat(frontend): protect dashboard routes with middleware + auth guard — #25

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const PROTECTED_ROUTES = ['/dashboard']
+const AUTH_ROUTES = ['/login', '/register']
+
+interface PersistedAuthState {
+  state: {
+    token: string | null
+    user: { id: string; name: string; email: string } | null
+    isAuthenticated: boolean
+  }
+  version?: number
+}
+
+const parseAuthCookie = (request: NextRequest): string | null => {
+  const authCookie = request.cookies.get('postflow-auth')
+  if (!authCookie?.value) return null
+
+  try {
+    const data = JSON.parse(
+      decodeURIComponent(authCookie.value)
+    ) as PersistedAuthState
+
+    const token = data?.state?.token
+    return typeof token === 'string' && token.length > 0 ? token : null
+  } catch {
+    return null
+  }
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const token = parseAuthCookie(request)
+  const isAuthenticated = token !== null
+
+  const isProtectedRoute = PROTECTED_ROUTES.some(route =>
+    pathname.startsWith(route)
+  )
+
+  if (isProtectedRoute && !isAuthenticated) {
+    const loginUrl = new URL('/login', request.url)
+    loginUrl.searchParams.set('redirect', pathname)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  const isAuthRoute = AUTH_ROUTES.some(route => pathname.startsWith(route))
+  if (isAuthRoute && isAuthenticated) {
+    return NextResponse.redirect(new URL('/dashboard', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/login', '/register'],
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,9 +1,30 @@
 import React from 'react'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 import { AuthSidebar } from '@/features/auth/components/AuthSidebar'
 import { LoginForm } from '@/features/auth/components/LoginForm/LoginForm'
 import { Globe } from 'lucide-react'
 
-export default function LoginPage() {
+const getTokenFromAuthCookie = async (): Promise<string | null> => {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('postflow-auth')?.value
+  if (!cookieValue) return null
+
+  try {
+    const data = JSON.parse(decodeURIComponent(cookieValue)) as {
+      state?: { token?: unknown } | undefined
+    }
+    const token = data?.state?.token
+    return typeof token === 'string' && token.length > 0 ? token : null
+  } catch {
+    return null
+  }
+}
+
+export default async function LoginPage() {
+  const token = await getTokenFromAuthCookie()
+  if (token) redirect('/dashboard')
+
   return (
     <div className="flex min-h-screen w-full bg-white">
       {/* Sidebar - Hidden on mobile */}

--- a/frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import Link from 'next/link'
+import { useLogout } from '@/features/auth'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+
+export default function DashboardPage() {
+  const { user, isAuthenticated } = useCurrentUser()
+  const { mutate: logout, isPending } = useLogout()
+
+  return (
+    <div className="min-h-screen p-6 flex flex-col gap-4">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <div className="rounded border bg-white p-4 text-sm flex flex-col gap-1">
+        <div>
+          Authentifié: <span className="font-medium">{String(isAuthenticated)}</span>
+        </div>
+        <div>Nom: {user?.name || '—'}</div>
+        <div>Email: {user?.email || '—'}</div>
+      </div>
+      <div className="flex gap-2">
+        <Link
+          href="/dashboard/posts"
+          className="h-10 px-3 rounded border grid place-items-center"
+        >
+          Aller à Posts
+        </Link>
+        <button
+          onClick={() => logout()}
+          disabled={isPending}
+          className="h-10 w-fit px-3 rounded bg-black text-white disabled:opacity-50"
+        >
+          {isPending ? '...' : 'Logout'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/dashboard/posts/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/posts/page.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import Link from 'next/link'
+import { useLogout } from '@/features/auth'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+
+export default function DashboardPostsPage() {
+  const { user } = useCurrentUser()
+  const { mutate: logout, isPending } = useLogout()
+
+  return (
+    <div className="min-h-screen p-6 flex flex-col gap-4">
+      <h1 className="text-2xl font-semibold">Dashboard / Posts</h1>
+      <div className="text-sm text-zinc-600">Bonjour {user?.name || '—'}</div>
+      <div className="flex gap-2">
+        <Link href="/dashboard" className="h-10 px-3 rounded border grid place-items-center">
+          Retour dashboard
+        </Link>
+        <button
+          onClick={() => logout()}
+          disabled={isPending}
+          className="h-10 px-3 rounded bg-black text-white disabled:opacity-50"
+        >
+          {isPending ? '...' : 'Logout'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
+import { AuthGuard } from '@/features/auth/components/AuthGuard'
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
-  return <>{children}</>
+  return <AuthGuard>{children}</AuthGuard>
 }

--- a/frontend/src/features/auth/components/AuthGuard/AuthGuard.tsx
+++ b/frontend/src/features/auth/components/AuthGuard/AuthGuard.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/store/auth.store'
+import type { ReactNode } from 'react'
+
+interface AuthGuardProps {
+  children: ReactNode
+}
+
+export const AuthGuard = ({ children }: AuthGuardProps) => {
+  const hasHydrated = useAuthStore(state => state.hasHydrated)
+  const isAuthenticated = useAuthStore(state => state.isAuthenticated)
+  const router = useRouter()
+
+  useEffect(() => {
+    if (hasHydrated && !isAuthenticated) {
+      router.push('/login')
+    }
+  }, [hasHydrated, isAuthenticated, router])
+
+  if (!hasHydrated) {
+    return null
+  }
+
+  if (!isAuthenticated) {
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/frontend/src/features/auth/components/AuthGuard/index.ts
+++ b/frontend/src/features/auth/components/AuthGuard/index.ts
@@ -1,0 +1,1 @@
+export { AuthGuard } from './AuthGuard'

--- a/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -8,10 +8,11 @@ import { Eye, EyeOff, Mail, Lock } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/shad_ui/input'
 import { loginSchema, type LoginFormData } from '../../types/auth.schemas'
+import { useLogin } from '@/features/auth/hooks/useAuth'
 
 export const LoginForm = () => {
   const [showPassword, setShowPassword] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const { mutate, isPending, error } = useLogin()
 
   const {
     register,
@@ -22,10 +23,7 @@ export const LoginForm = () => {
   })
 
   const onSubmit = async (data: LoginFormData) => {
-    setIsLoading(true)
-    // Simulation d'appel API
-    console.log('Données de connexion:', data)
-    setTimeout(() => setIsLoading(false), 1500)
+    mutate(data)
   }
 
   return (
@@ -137,12 +135,18 @@ export const LoginForm = () => {
 
           <Button
             type="submit"
-            disabled={isLoading}
+            disabled={isPending}
             className="w-full cursor-pointer py-6 text-base font-bold bg-[#6366f1] hover:bg-[#4f46e5] text-white rounded-xl shadow-lg shadow-indigo-200 transition-all hover:scale-[1.01] active:scale-[0.99]"
           >
-            {isLoading ? 'Connexion en cours...' : 'Se connecter'}
+            {isPending ? 'Connexion en cours...' : 'Se connecter'}
           </Button>
         </form>
+
+        {error && (
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error.message}
+          </div>
+        )}
 
         {/* Footer Link */}
         <p className="text-center text-sm text-gray-600">

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMutation } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { authService } from '@/features/auth/services/auth.service'
 import { useAuthStore } from '@/store/auth.store'
 import type {
@@ -12,12 +12,14 @@ import type {
 export const useLogin = () => {
   const setUser = useAuthStore(state => state.setUser)
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const redirectTo = searchParams.get('redirect')
 
   return useMutation({
     mutationFn: (credentials: LoginRequest) => authService.login(credentials),
     onSuccess: data => {
       setUser(data.user, data.token)
-      router.push('/dashboard')
+      router.push(redirectTo || '/dashboard')
     },
     onError: (error: Error) => {
       console.error('Erreur login:', error.message)

--- a/frontend/src/store/auth.store.ts
+++ b/frontend/src/store/auth.store.ts
@@ -8,8 +8,10 @@ interface AuthState {
   user: User | null
   token: string | null
   isAuthenticated: boolean
+  hasHydrated: boolean
   setUser: (user: User, token: string) => void
   clearAuth: () => void
+  setHasHydrated: (value: boolean) => void
 }
 
 const setAuthCookie = (user: User, token: string) => {
@@ -33,6 +35,7 @@ export const useAuthStore = create<AuthState>()(
       user: null,
       token: null,
       isAuthenticated: false,
+      hasHydrated: false,
       setUser: (user, token) => {
         setAuthCookie(user, token)
         set({ user, token, isAuthenticated: true })
@@ -41,6 +44,7 @@ export const useAuthStore = create<AuthState>()(
         clearAuthCookie()
         set({ user: null, token: null, isAuthenticated: false })
       },
+      setHasHydrated: hasHydrated => set({ hasHydrated }),
     }),
     {
       name: 'postflow-auth',
@@ -50,6 +54,9 @@ export const useAuthStore = create<AuthState>()(
         user: state.user,
         isAuthenticated: state.isAuthenticated,
       }),
+      onRehydrateStorage: () => state => {
+        state?.setHasHydrated(true)
+      },
     }
   )
 )


### PR DESCRIPTION
## Résumé
- Ajoute un `middleware.ts` pour protéger `/dashboard/**` et rediriger vers `/login?redirect=...`
- Bloque l’accès à `/login` et `/register` si déjà authentifié (redirect `/dashboard`)
- Ajoute `AuthGuard` côté client pour protéger le layout dashboard (fallback UI)
- Ajoute un flag `hasHydrated` au store auth pour éviter le flicker au refresh
- Ajoute des pages de test minimalistes: `/dashboard` + `/dashboard/posts` + bouton logout

## Checklist
- `pnpm lint`
- `pnpm build` (bloqué uniquement par l’erreur zodResolver connue, à ignorer selon consigne lead)

## Tests manuels

### 1) Pré-requis
- Auth mock activée (si besoin):

```env
NEXT_PUBLIC_USE_MOCK=true
```

### 2) Cas attendus
- Déconnecté → aller sur `/dashboard` ou `/dashboard/posts`
  - attendu: redirect `/login?redirect=/dashboard` ou `/login?redirect=/dashboard/posts`
- Connecté → aller sur `/login`
  - attendu: redirect serveur immédiat vers `/dashboard` (sans flicker)
- Refresh sur `/dashboard` connecté
  - attendu: aucun flash `/login`
- Depuis `/dashboard`, bouton “Aller à Posts” → `/dashboard/posts` OK
- Logout sur dashboard → retour `/login` + `/dashboard` doit re-rediriger `/login?redirect=...`

## Rollback
- Supprimer `frontend/middleware.ts` + `AuthGuard` et retirer le guard du layout dashboard