### PR TITLE
feat(frontend): hooks TanStack Query pour Social Accounts (Closes #83)

### DIFF
--- a/frontend/src/features/social/hooks/useSocialAccounts.ts
+++ b/frontend/src/features/social/hooks/useSocialAccounts.ts
@@ -1,0 +1,64 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import env from '@/config/env'
+import { socialService } from '@/features/social/services/social.service'
+import type {
+  ConnectSocialAccountRequest,
+  ConnectSocialAccountResponse,
+  Platform,
+  SocialAccount,
+} from '@/features/social/types/social.types'
+import { useAuthStore } from '@/store/auth.store'
+
+const socialKeys = {
+  accounts: (userId: string) => ['social', 'accounts', userId] as const,
+}
+
+export function useSocialAccounts() {
+  const userId = useAuthStore(s => s.user?.id) ?? 'anonymous'
+  const isAuthenticated = useAuthStore(s => s.isAuthenticated)
+  const hasHydrated = useAuthStore(s => s.hasHydrated)
+
+  return useQuery<SocialAccount[], Error>({
+    queryKey: socialKeys.accounts(userId),
+    queryFn: async () => {
+      const res = await socialService.getAccounts()
+      return res.accounts
+    },
+    enabled: env.useMock || (hasHydrated && isAuthenticated),
+  })
+}
+
+export function useConnectSocialAccount() {
+  return useMutation<ConnectSocialAccountResponse, Error, ConnectSocialAccountRequest>(
+    {
+      mutationFn: input => socialService.getConnectUrl(input),
+      onSuccess: ({ redirectUrl }) => {
+        window.location.assign(redirectUrl)
+      },
+    }
+  )
+}
+
+export function useDisconnectSocialAccount() {
+  const qc = useQueryClient()
+  const userId = useAuthStore(s => s.user?.id) ?? 'anonymous'
+
+  return useMutation({
+    mutationFn: (accountId: string) => socialService.disconnect(accountId),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: socialKeys.accounts(userId) })
+    },
+  })
+}
+
+export function useSocialAccountByPlatform(platform: Platform) {
+  const query = useSocialAccounts()
+
+  const account = query.data?.find(a => a.platform === platform) ?? null
+  const isConnected = account?.status === 'CONNECTED'
+
+  return { ...query, account, isConnected }
+}
+

--- a/frontend/src/features/social/index.ts
+++ b/frontend/src/features/social/index.ts
@@ -11,3 +11,10 @@ export type {
 } from './types/social.types'
 
 export { PLATFORM_CONFIG } from './types/social.types'
+
+export {
+  useSocialAccounts,
+  useConnectSocialAccount,
+  useDisconnectSocialAccount,
+  useSocialAccountByPlatform,
+} from './hooks/useSocialAccounts'

--- a/frontend/src/features/social/mocks/social.mock.ts
+++ b/frontend/src/features/social/mocks/social.mock.ts
@@ -5,7 +5,6 @@ import type { ConnectSocialAccountResponse, DisconnectSocialAccountResponse, Get
 export const mockFacebookAccount: SocialAccount = {
     id: "acc_1234567890",
     platform: "FACEBOOK",
-    userId: mockUser.id,
     platformUserId: "12345678909094667475737646",
     name: "PostFlow",
     avatar: "https://ui-avatars.com/api/?name=PostFlow&background=1877F2&color=fff",
@@ -17,11 +16,10 @@ export const mockFacebookAccount: SocialAccount = {
 export const mockLinkedInAccount: SocialAccount = {
     id: "acc_1234567891",
     platform: "LINKEDIN",
-    userId: mockUser.id,
     platformUserId: "1234567891",
     name: mockUser.name,
     avatar: "https://ui-avatars.com/api/?name=PostFlow&background=0A66C2&color=fff",
-    status: "CONNECTED",
+    status: "EXPIRED",
     connectedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
     expiresAt: new Date(Date.now() + 53 * 24 * 60 * 60 * 1000).toISOString(),
 }


### PR DESCRIPTION
- Implémenter useSocialAccounts , useConnectSocialAccount , useDisconnectSocialAccount , useSocialAccountByPlatform via TanStack Query.
- Interdire l’accès direct au socialService depuis les composants en exposant uniquement des hooks.
- connect redirige vers redirectUrl au succès (client-only).
- disconnect invalide le cache des comptes → refresh automatique de la liste.
- Ajuster les mocks Social : LinkedIn en EXPIRED et suppression du champ non typé pour respecter les critères d’acceptation.
Fichiers

- Ajout : useSocialAccounts.ts
- Modif : social/index.ts
- Modif : social.mock.ts
Validation

- pnpm build OK (frontend)
Checklist

- Closes #83
- Aucun accès window hors code client (hooks en 'use client' , redirect uniquement en onSuccess )