### PR TITLE
Feature/backend/login logout refresh token usecases

### DIFF
--- a/backend/src/main/java/io/ketherlabs/postflow/identity/application/handler/IdentityExceptionHandler.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/application/handler/IdentityExceptionHandler.java
@@ -29,10 +29,40 @@ public class IdentityExceptionHandler {
                 .body(new ErrorResponse("ACCOUNT_SUSPENDED", ex.getMessage()));
     }
 
+    @ExceptionHandler(AccountNotActiveException.class)
+    public ResponseEntity<ErrorResponse> handleAccountNotActiveException(AccountNotActiveException ex) {
+        return ResponseEntity.status(403)
+                .body(new ErrorResponse("ACCOUNT_NOT_ACTIVE", ex.getMessage()));
+    }
+
     @ExceptionHandler(EmailAlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handleEmailAlreadyExistsException(EmailAlreadyExistsException ex) {
         return ResponseEntity.status(409)
                 .body(new ErrorResponse("EMAIL_ALREADY_EXISTS", ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentialsException(InvalidCredentialsException ex) {
+        return ResponseEntity.status(401)
+                .body(new ErrorResponse("INVALID_CREDENTIALS", ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRefreshTokenException(InvalidRefreshTokenException ex) {
+        return ResponseEntity.status(401)
+                .body(new ErrorResponse("INVALID_REFRESH_TOKEN", ex.getMessage()));
+    }
+
+    @ExceptionHandler(RefreshTokenExpiredException.class)
+    public ResponseEntity<ErrorResponse> handleRefreshTokenExpiredException(RefreshTokenExpiredException ex) {
+        return ResponseEntity.status(401)
+                .body(new ErrorResponse("REFRESH_TOKEN_EXPIRED", ex.getMessage()));
+    }
+
+    @ExceptionHandler(RefreshTokenRevokedException.class)
+    public ResponseEntity<ErrorResponse> handleRefreshTokenRevokedException(RefreshTokenRevokedException ex) {
+        return ResponseEntity.status(401)
+                .body(new ErrorResponse("REFRESH_TOKEN_REVOKED", ex.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/AccountNotActiveException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/AccountNotActiveException.java
@@ -1,0 +1,7 @@
+package io.ketherlabs.postflow.identity.domain.exception;
+
+public class AccountNotActiveException extends RuntimeException {
+    public AccountNotActiveException(String email) {
+        super("The account with email " + email + " is not active. Please activate your account and try again.");
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/InvalidCredentialsException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package io.ketherlabs.postflow.identity.domain.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException() {
+        super("Invalid email or password");
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/InvalidRefreshTokenException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/InvalidRefreshTokenException.java
@@ -1,7 +1,7 @@
 package io.ketherlabs.postflow.identity.domain.exception;
 
 public class InvalidRefreshTokenException extends RuntimeException {
-    public InvalidRefreshTokenException(String refreshToken) {
-        super("Invalid refresh token: " + refreshToken);
+    public InvalidRefreshTokenException() {
+        super("Invalid refresh token");
     }
 }

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/InvalidRefreshTokenException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package io.ketherlabs.postflow.identity.domain.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+    public InvalidRefreshTokenException(String refreshToken) {
+        super("Invalid refresh token: " + refreshToken);
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenExpiredException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,7 @@
+package io.ketherlabs.postflow.identity.domain.exception;
+
+public class RefreshTokenExpiredException extends RuntimeException {
+    public RefreshTokenExpiredException(String refreshToken) {
+        super("Refresh token expired: " + refreshToken);
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenExpiredException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenExpiredException.java
@@ -1,7 +1,7 @@
 package io.ketherlabs.postflow.identity.domain.exception;
 
 public class RefreshTokenExpiredException extends RuntimeException {
-    public RefreshTokenExpiredException(String refreshToken) {
-        super("Refresh token expired: " + refreshToken);
+    public RefreshTokenExpiredException() {
+        super("Refresh token expired");
     }
 }

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenRevokedException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenRevokedException.java
@@ -1,7 +1,7 @@
 package io.ketherlabs.postflow.identity.domain.exception;
 
 public class RefreshTokenRevokedException extends RuntimeException {
-    public RefreshTokenRevokedException(String refreshToken) {
-        super("Refresh token revoked: " + refreshToken);
+    public RefreshTokenRevokedException() {
+        super("Refresh token revoked");
     }
 }

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenRevokedException.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/exception/RefreshTokenRevokedException.java
@@ -1,0 +1,7 @@
+package io.ketherlabs.postflow.identity.domain.exception;
+
+public class RefreshTokenRevokedException extends RuntimeException {
+    public RefreshTokenRevokedException(String refreshToken) {
+        super("Refresh token revoked: " + refreshToken);
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/port/JwtTokenPort.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/port/JwtTokenPort.java
@@ -55,4 +55,16 @@ public interface JwtTokenPort {
      */
     boolean isValid(String accessToken);
 
+    /**
+     * Retourne le temps résiduel du token en secondes ({@code exp - now}).
+     *
+     * <p>Utilisé par {@code LogoutUseCase} (UC-AUTH-005) pour fixer le TTL
+     * Redis de la blacklist, afin que l'entrée expire naturellement en même
+     * temps que le token.
+     *
+     * @param accessToken le JWT à parser
+     * @return les secondes jusqu'à expiration, {@code 0} si déjà expiré
+     */
+    long getRemainingTtlSeconds(String accessToken);
+
 }

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/port/RefreshTokenPort.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/port/RefreshTokenPort.java
@@ -1,0 +1,25 @@
+package io.ketherlabs.postflow.identity.domain.port;
+
+import io.ketherlabs.postflow.identity.domain.entity.User;
+
+/**
+ * Port pour générer et valider les Refresh Tokens.
+ */
+public interface RefreshTokenPort {
+
+    /**
+     * Génère un nouveau Refresh Token opaque (UUID).
+     *
+     * @param user l'utilisateur pour lequel générer le token
+     * @return le token (UUID) à retourner au client
+     */
+    String generateRefreshToken(User user);
+
+    /**
+     * Vérifie si un Refresh Token est valide.
+     *
+     * @param tokenHash le hash du token stocké en base
+     * @return true si le token est valide et non expiré
+     */
+    boolean isValid(String tokenHash);
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/LoginUseCase.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/LoginUseCase.java
@@ -10,59 +10,80 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
+/**
+ * Use case UC-AUTH-003 : Authentification d'un utilisateur.
+ *
+ * <p>Flux principal :
+ * <ol>
+ *   <li>Charger l'utilisateur par email — sinon {@link InvalidCredentialsException}</li>
+ *   <li>Vérifier que le compte est autorisé à se connecter (statut ACTIVE)</li>
+ *   <li>Comparer le mot de passe saisi au hash stocké — sinon {@link InvalidCredentialsException}</li>
+ *   <li>Générer un Access Token JWT via {@code JwtTokenPort}</li>
+ *   <li>Générer un Refresh Token opaque via {@code RefreshTokenPort}</li>
+ *   <li>Hasher le Refresh Token via {@code PasswordEncoderPort} et le persister (TTL 7j)</li>
+ *   <li>Mettre à jour la date de dernière connexion sur l'utilisateur</li>
+ * </ol>
+ */
 public class LoginUseCase {
 
-    private final UserRepositoryPort userRepositoryPort;
-    private final JwtTokenPort jwtTokenPort;
-    private final RefreshTokenRepositoryPort refreshTokenRepositoryPort;
-    private final RefreshTokenPort refreshTokenPort;
-    private final PasswordEncoderPort passwordEncoder;
+    private final UserRepositoryPort           userRepositoryPort;
+    private final JwtTokenPort                 jwtTokenPort;
+    private final RefreshTokenRepositoryPort   refreshTokenRepositoryPort;
+    private final RefreshTokenPort             refreshTokenPort;
+    private final PasswordEncoderPort          passwordEncoder;
 
     public LoginUseCase(UserRepositoryPort userRepositoryPort,
                         JwtTokenPort jwtTokenPort,
                         RefreshTokenRepositoryPort refreshTokenRepositoryPort,
                         RefreshTokenPort refreshTokenPort,
                         PasswordEncoderPort passwordEncoder) {
-        this.userRepositoryPort = userRepositoryPort;
-        this.jwtTokenPort = jwtTokenPort;
+        this.userRepositoryPort         = userRepositoryPort;
+        this.jwtTokenPort               = jwtTokenPort;
         this.refreshTokenRepositoryPort = refreshTokenRepositoryPort;
-        this.refreshTokenPort = refreshTokenPort;
-        this.passwordEncoder = passwordEncoder;
+        this.refreshTokenPort           = refreshTokenPort;
+        this.passwordEncoder            = passwordEncoder;
     }
 
+    /**
+     * Exécute l'authentification d'un utilisateur.
+     *
+     * @param command la commande contenant l'email et le mot de passe
+     * @return une réponse contenant l'Access Token JWT et le Refresh Token opaque
+     * @throws InvalidCredentialsException si l'email est inconnu ou le mot de passe invalide
+     */
     @Transactional
     public LoginResponse execute(LoginCommand command) {
 
-        // Charger l'utilisateur de la base de donnees
+        // 1. Charger l'utilisateur par email
         User user = userRepositoryPort.findByEmail(command.email())
                 .orElseThrow(InvalidCredentialsException::new);
 
-        // Verification du status du compte de l'utilisateur (doit être ACTIVE pour se connecter)
+        // 2. Vérifier que le compte est autorisé à se connecter (statut ACTIVE)
         user.assertCanLogin();
 
-        // Comparaison du mot de passe avec celui enregistré dans la base de donnees
+        // 3. Comparer le mot de passe saisi au hash stocké
         if (!passwordEncoder.matches(command.password(), user.getPassword().getHashedValue())) {
             throw new InvalidCredentialsException();
         }
 
-        // Génère un JWT access token
+        // 4. Générer un Access Token JWT
         String accessToken = jwtTokenPort.generateAccessToken(user);
 
-        // Génère un Refresh Token opaque (UUID hashé et persisté)
+        // 5. Générer un Refresh Token opaque
         String rawRefreshToken = refreshTokenPort.generateRefreshToken(user);
-        String tokenHash = passwordEncoder.encode(rawRefreshToken);
 
+        // 6. Hasher et persister le Refresh Token (TTL 7j)
+        String tokenHash = passwordEncoder.encode(rawRefreshToken);
         RefreshToken refreshToken = RefreshToken.create(
                 tokenHash,
-                Instant.now().plusSeconds(7 * 24 * 3600),   // TTL 7j
+                Instant.now().plusSeconds(7 * 24 * 3600),
                 user.getId()
         );
         refreshTokenRepositoryPort.save(refreshToken);
 
-        // Enregistre la date de dernière connexion
+        // 7. Mettre à jour la date de dernière connexion
         user.updateLastLogin();
 
-        // Retourne la réponse avec les tokens
         return new LoginResponse(accessToken, rawRefreshToken);
     }
 

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/LoginUseCase.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/LoginUseCase.java
@@ -1,0 +1,69 @@
+package io.ketherlabs.postflow.identity.domain.usecase;
+
+import io.ketherlabs.postflow.identity.domain.entity.RefreshToken;
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.exception.InvalidCredentialsException;
+import io.ketherlabs.postflow.identity.domain.port.*;
+import io.ketherlabs.postflow.identity.domain.usecase.input.LoginCommand;
+import io.ketherlabs.postflow.identity.domain.usecase.output.LoginResponse;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+public class LoginUseCase {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final JwtTokenPort jwtTokenPort;
+    private final RefreshTokenRepositoryPort refreshTokenRepositoryPort;
+    private final RefreshTokenPort refreshTokenPort;
+    private final PasswordEncoderPort passwordEncoder;
+
+    public LoginUseCase(UserRepositoryPort userRepositoryPort,
+                        JwtTokenPort jwtTokenPort,
+                        RefreshTokenRepositoryPort refreshTokenRepositoryPort,
+                        RefreshTokenPort refreshTokenPort,
+                        PasswordEncoderPort passwordEncoder) {
+        this.userRepositoryPort = userRepositoryPort;
+        this.jwtTokenPort = jwtTokenPort;
+        this.refreshTokenRepositoryPort = refreshTokenRepositoryPort;
+        this.refreshTokenPort = refreshTokenPort;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public LoginResponse execute(LoginCommand command) {
+
+        // Charger l'utilisateur de la base de donnees
+        User user = userRepositoryPort.findByEmail(command.email())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        // Verification du status du compte de l'utilisateur (doit être ACTIVE pour se connecter)
+        user.assertCanLogin();
+
+        // Comparaison du mot de passe avec celui enregistré dans la base de donnees
+        if (!passwordEncoder.matches(command.password(), user.getPassword().getHashedValue())) {
+            throw new InvalidCredentialsException();
+        }
+
+        // Génère un JWT access token
+        String accessToken = jwtTokenPort.generateAccessToken(user);
+
+        // Génère un Refresh Token opaque (UUID hashé et persisté)
+        String rawRefreshToken = refreshTokenPort.generateRefreshToken(user);
+        String tokenHash = passwordEncoder.encode(rawRefreshToken);
+
+        RefreshToken refreshToken = RefreshToken.create(
+                tokenHash,
+                Instant.now().plusSeconds(7 * 24 * 3600),   // TTL 7j
+                user.getId()
+        );
+        refreshTokenRepositoryPort.save(refreshToken);
+
+        // Enregistre la date de dernière connexion
+        user.updateLastLogin();
+
+        // Retourne la réponse avec les tokens
+        return new LoginResponse(accessToken, rawRefreshToken);
+    }
+
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/LogoutUseCase.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/LogoutUseCase.java
@@ -1,0 +1,65 @@
+package io.ketherlabs.postflow.identity.domain.usecase;
+
+import io.ketherlabs.postflow.identity.domain.port.JwtTokenPort;
+import io.ketherlabs.postflow.identity.domain.port.PasswordEncoderPort;
+import io.ketherlabs.postflow.identity.domain.port.RedisBlacklistPort;
+import io.ketherlabs.postflow.identity.domain.port.RefreshTokenRepositoryPort;
+import io.ketherlabs.postflow.identity.domain.usecase.input.LogoutCommand;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Use case UC-AUTH-005 : Déconnexion d'un utilisateur.
+ *
+ * <p>Flux principal :
+ * <ol>
+ *   <li>Extraire le {@code jti} et le TTL résiduel de l'Access Token JWT via {@code JwtTokenPort}</li>
+ *   <li>Blacklister le {@code jti} dans Redis avec le TTL résiduel pour invalider l'Access Token avant son expiration naturelle</li>
+ *   <li>Hasher le Refresh Token reçu et le rechercher en base</li>
+ *   <li>Si le Refresh Token existe, le révoquer (la session courante est fermée)</li>
+ * </ol>
+ *
+ * <p>Ne révoque que le Refresh Token de la session courante — les autres sessions
+ * actives de l'utilisateur (autres appareils) restent valides.
+ */
+public class LogoutUseCase {
+
+    private final RefreshTokenRepositoryPort refreshTokenRepository;
+    private final JwtTokenPort               jwtTokenPort;
+    private final RedisBlacklistPort         redisBlacklistPort;
+    private final PasswordEncoderPort        passwordEncoder;
+
+    public LogoutUseCase(RefreshTokenRepositoryPort refreshTokenRepository,
+                         JwtTokenPort jwtTokenPort,
+                         RedisBlacklistPort redisBlacklistPort,
+                         PasswordEncoderPort passwordEncoder) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtTokenPort           = jwtTokenPort;
+        this.redisBlacklistPort     = redisBlacklistPort;
+        this.passwordEncoder        = passwordEncoder;
+    }
+
+    /**
+     * Exécute la déconnexion d'un utilisateur.
+     *
+     * @param command la commande contenant l'Access Token et le Refresh Token de la session courante
+     * @throws IllegalArgumentException si l'Access Token ou le Refresh Token est null ou vide (validé par {@link LogoutCommand})
+     */
+    @Transactional
+    public void execute(LogoutCommand command) {
+
+        // 1. Extraire le jti de l'Access Token
+        String jti = jwtTokenPort.extractJti(command.accessToken());
+
+        // 2. Extraire le TTL résiduel de l'Access Token
+        long ttlSeconds = jwtTokenPort.getRemainingTtlSeconds(command.accessToken());
+
+        // 3. Blacklister le jti dans Redis avec le TTL résiduel
+        redisBlacklistPort.blacklist(jti, ttlSeconds);
+
+        // 4. Hasher le Refresh Token et le révoquer s'il existe en base
+        String refreshTokenHash = passwordEncoder.encode(command.refreshToken());
+        refreshTokenRepository.findByTokenHash(refreshTokenHash)
+                .ifPresent(refreshTokenRepository::revoke);
+    }
+
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/RefreshTokenUseCase.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/RefreshTokenUseCase.java
@@ -68,16 +68,16 @@ public class RefreshTokenUseCase {
         // 2. Hasher et rechercher le token en base
         String tokenHash = passwordEncoder.encode(refreshToken);
         RefreshToken refreshTokenEntity = refreshTokenRepository.findByTokenHash(tokenHash)
-                .orElseThrow(() -> new InvalidRefreshTokenException(refreshToken));
+                .orElseThrow(InvalidRefreshTokenException::new);
 
         // 3. Vérifier TTL 7j
         if (refreshTokenEntity.isExpired()) {
-            throw new RefreshTokenExpiredException(refreshToken);
+            throw new RefreshTokenExpiredException();
         }
 
         // 4. Vérifier que le token n'est pas révoqué
         if (refreshTokenEntity.isRevoked()) {
-            throw new RefreshTokenRevokedException(refreshToken);
+            throw new RefreshTokenRevokedException();
         }
 
         // 5. Révoquer l'ancien token (rotation : usage unique)
@@ -85,7 +85,7 @@ public class RefreshTokenUseCase {
 
         // 6. Charger l'utilisateur associé
         User user = userRepository.findById(refreshTokenEntity.getUserId())
-                .orElseThrow(() -> new InvalidRefreshTokenException(refreshToken));
+                .orElseThrow(InvalidRefreshTokenException::new);
 
         // 7. Générer un nouvel Access Token JWT
         String newAccessToken = jwtTokenPort.generateAccessToken(user);

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/RefreshTokenUseCase.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/RefreshTokenUseCase.java
@@ -1,0 +1,108 @@
+package io.ketherlabs.postflow.identity.domain.usecase;
+
+import io.ketherlabs.postflow.identity.domain.entity.RefreshToken;
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.exception.InvalidRefreshTokenException;
+import io.ketherlabs.postflow.identity.domain.exception.RefreshTokenExpiredException;
+import io.ketherlabs.postflow.identity.domain.exception.RefreshTokenRevokedException;
+import io.ketherlabs.postflow.identity.domain.port.*;
+import io.ketherlabs.postflow.identity.domain.usecase.output.LoginResponse;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * Use case UC-AUTH-004 : Rotation d'un Refresh Token.
+ *
+ * <p>Flux principal :
+ * <ol>
+ *   <li>Valider que le Refresh Token fourni n'est pas null ou vide</li>
+ *   <li>Hasher le token reçu et le rechercher en base — sinon {@link InvalidRefreshTokenException}</li>
+ *   <li>Vérifier TTL 7j — sinon {@link RefreshTokenExpiredException}</li>
+ *   <li>Vérifier qu'il n'est pas révoqué — sinon {@link RefreshTokenRevokedException}</li>
+ *   <li>Révoquer l'ancien token (rotation : usage unique)</li>
+ *   <li>Charger l'utilisateur associé — sinon {@link InvalidRefreshTokenException}</li>
+ *   <li>Générer un nouvel Access Token JWT via {@code JwtTokenPort}</li>
+ *   <li>Générer un nouveau Refresh Token opaque via {@code RefreshTokenPort}</li>
+ *   <li>Hasher et persister le nouveau Refresh Token (TTL 7j)</li>
+ * </ol>
+ */
+public class RefreshTokenUseCase {
+
+    private final RefreshTokenRepositoryPort refreshTokenRepository;
+    private final JwtTokenPort               jwtTokenPort;
+    private final UserRepositoryPort         userRepository;
+    private final RefreshTokenPort           refreshTokenPort;
+    private final PasswordEncoderPort        passwordEncoder;
+
+    public RefreshTokenUseCase(RefreshTokenRepositoryPort refreshTokenRepository,
+                               JwtTokenPort jwtTokenPort,
+                               UserRepositoryPort userRepository,
+                               RefreshTokenPort refreshTokenPort,
+                               PasswordEncoderPort passwordEncoder) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtTokenPort           = jwtTokenPort;
+        this.userRepository         = userRepository;
+        this.refreshTokenPort       = refreshTokenPort;
+        this.passwordEncoder        = passwordEncoder;
+    }
+
+    /**
+     * Exécute la rotation d'un Refresh Token.
+     *
+     * @param refreshToken le Refresh Token opaque transmis par le client
+     * @return une réponse contenant le nouvel Access Token JWT et le nouveau Refresh Token
+     * @throws IllegalArgumentException        si le token est null ou vide
+     * @throws InvalidRefreshTokenException    si le token est introuvable ou l'utilisateur associé inexistant
+     * @throws RefreshTokenExpiredException    si le token a expiré (TTL 7j)
+     * @throws RefreshTokenRevokedException    si le token a déjà été révoqué
+     */
+    @Transactional
+    public LoginResponse execute(String refreshToken) {
+
+        // 1. Valider l'entrée
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new IllegalArgumentException("Refresh token must not be null or blank");
+        }
+
+        // 2. Hasher et rechercher le token en base
+        String tokenHash = passwordEncoder.encode(refreshToken);
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findByTokenHash(tokenHash)
+                .orElseThrow(() -> new InvalidRefreshTokenException(refreshToken));
+
+        // 3. Vérifier TTL 7j
+        if (refreshTokenEntity.isExpired()) {
+            throw new RefreshTokenExpiredException(refreshToken);
+        }
+
+        // 4. Vérifier que le token n'est pas révoqué
+        if (refreshTokenEntity.isRevoked()) {
+            throw new RefreshTokenRevokedException(refreshToken);
+        }
+
+        // 5. Révoquer l'ancien token (rotation : usage unique)
+        refreshTokenEntity.markAsRevoke();
+
+        // 6. Charger l'utilisateur associé
+        User user = userRepository.findById(refreshTokenEntity.getUserId())
+                .orElseThrow(() -> new InvalidRefreshTokenException(refreshToken));
+
+        // 7. Générer un nouvel Access Token JWT
+        String newAccessToken = jwtTokenPort.generateAccessToken(user);
+
+        // 8. Générer un nouveau Refresh Token opaque
+        String newRefreshToken = refreshTokenPort.generateRefreshToken(user);
+
+        // 9. Hasher et persister le nouveau Refresh Token (TTL 7j)
+        String newTokenHash = passwordEncoder.encode(newRefreshToken);
+        RefreshToken newRefreshTokenEntity = RefreshToken.create(
+                newTokenHash,
+                Instant.now().plusSeconds(7 * 24 * 3600),
+                user.getId()
+        );
+        refreshTokenRepository.save(newRefreshTokenEntity);
+
+        return new LoginResponse(newAccessToken, newRefreshToken);
+    }
+
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/RegisterUseCase.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/RegisterUseCase.java
@@ -6,12 +6,12 @@ import io.ketherlabs.postflow.identity.domain.entity.valueobject.Email;
 import io.ketherlabs.postflow.identity.domain.entity.valueobject.Password;
 import io.ketherlabs.postflow.identity.domain.event.UserRegisteredEvent;
 import io.ketherlabs.postflow.identity.domain.exception.EmailAlreadyExistsException;
+import io.ketherlabs.postflow.identity.domain.port.PasswordEncoderPort;
 import io.ketherlabs.postflow.identity.domain.port.UserRepositoryPort;
 import io.ketherlabs.postflow.identity.domain.port.VerificationTokenRepositoryPort;
 import io.ketherlabs.postflow.identity.domain.usecase.input.RegisterCommand;
 import io.ketherlabs.postflow.identity.domain.usecase.output.RegisterResponse;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -21,11 +21,16 @@ public class RegisterUseCase {
 
     private final UserRepositoryPort userRepositoryPort;
     private final VerificationTokenRepositoryPort tokenRepositoryPort;
+    private final PasswordEncoderPort passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
 
-    public RegisterUseCase(UserRepositoryPort userRepositoryPort, VerificationTokenRepositoryPort tokenRepositoryPort, ApplicationEventPublisher eventPublisher) {
+    public RegisterUseCase(UserRepositoryPort userRepositoryPort,
+                           VerificationTokenRepositoryPort tokenRepositoryPort,
+                           PasswordEncoderPort passwordEncoder,
+                           ApplicationEventPublisher eventPublisher) {
         this.userRepositoryPort = userRepositoryPort;
         this.tokenRepositoryPort = tokenRepositoryPort;
+        this.passwordEncoder = passwordEncoder;
         this.eventPublisher = eventPublisher;
     }
 
@@ -44,7 +49,7 @@ public class RegisterUseCase {
         }
 
         // Hashage du mot de passe avec BCrypt cost factor 12
-        String hashedPassword = new BCryptPasswordEncoder(12).encode(command.password());
+        String hashedPassword = passwordEncoder.encode(command.password());
 
 
         // Crée l'utilisateur via la méthode factory de l'entité

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/input/LoginCommand.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/input/LoginCommand.java
@@ -1,0 +1,18 @@
+package io.ketherlabs.postflow.identity.domain.usecase.input;
+
+public record LoginCommand(
+        String email,
+        String password
+) {
+
+    public LoginCommand {
+
+        if (email == null || email.isBlank()) throw new IllegalArgumentException("Email is required");
+
+        if (!email.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"))
+            throw new IllegalArgumentException("Invalid email format: " + email);
+
+        if (password == null || password.isBlank()) throw new IllegalArgumentException("Password is required");
+    }
+
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/input/LogoutCommand.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/input/LogoutCommand.java
@@ -1,0 +1,16 @@
+package io.ketherlabs.postflow.identity.domain.usecase.input;
+
+public record LogoutCommand(
+        String accessToken,
+        String refreshToken
+) {
+
+    public LogoutCommand {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalArgumentException("Access token must not be null or blank");
+        }
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new IllegalArgumentException("Refresh token must not be null or blank");
+        }
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/output/LoginResponse.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/usecase/output/LoginResponse.java
@@ -1,0 +1,7 @@
+package io.ketherlabs.postflow.identity.domain.usecase.output;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/infrastructure/adpater/JwtAdapter.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/infrastructure/adpater/JwtAdapter.java
@@ -147,6 +147,22 @@ public class JwtAdapter implements JwtTokenPort {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Calcule {@code exp - now} à partir du claim {@code exp} du JWT.
+     * Retourne {@code 0} si le token est déjà expiré (évite de stocker
+     * une clé Redis avec un TTL négatif).
+     *
+     * @throws JwtException si le token est invalide ou expiré
+     */
+    @Override
+    public long getRemainingTtlSeconds(String accessToken) {
+        Instant expiration = parseClaims(accessToken).getExpiration().toInstant();
+        long remaining = expiration.getEpochSecond() - Instant.now().getEpochSecond();
+        return Math.max(remaining, 0L);
+    }
+
 
     /**
      * Parse et valide un JWT en vérifiant la signature RS256 et l'expiration.

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/FakeJwtTokenAdapter.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/FakeJwtTokenAdapter.java
@@ -1,0 +1,49 @@
+package io.ketherlabs.postflow.identity;
+
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.port.JwtTokenPort;
+
+import java.util.*;
+
+public class FakeJwtTokenAdapter implements JwtTokenPort {
+
+    private final Map<String, TokenPayload> tokens = new HashMap<>();
+    private final Set<String> invalidatedTokens = new HashSet<>();
+
+    @Override
+    public String generateAccessToken(User user) {
+        String jti = UUID.randomUUID().toString();
+        String token = "fake-access-token-" + jti;
+        tokens.put(token, new TokenPayload(user.getId(), user.getEmail().getValue(), jti));
+        return token;
+    }
+
+    @Override
+    public String extractJti(String accessToken) {
+        TokenPayload payload = tokens.get(accessToken);
+        if (payload == null) {
+            throw new IllegalArgumentException("Token inconnu : " + accessToken);
+        }
+        return payload.jti();
+    }
+
+    @Override
+    public UUID extractUserId(String accessToken) {
+        TokenPayload payload = tokens.get(accessToken);
+        if (payload == null) {
+            throw new IllegalArgumentException("Token inconnu : " + accessToken);
+        }
+        return payload.userId();
+    }
+
+    @Override
+    public boolean isValid(String accessToken) {
+        return tokens.containsKey(accessToken) && !invalidatedTokens.contains(accessToken);
+    }
+
+    public void invalidate(String accessToken) {
+        invalidatedTokens.add(accessToken);
+    }
+
+    private record TokenPayload(UUID userId, String email, String jti) {}
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/FakeJwtTokenAdapter.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/FakeJwtTokenAdapter.java
@@ -1,20 +1,22 @@
 package io.ketherlabs.postflow.identity;
 
 import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.exception.InvalidTokenException;
 import io.ketherlabs.postflow.identity.domain.port.JwtTokenPort;
 
+import java.time.Instant;
 import java.util.*;
 
 public class FakeJwtTokenAdapter implements JwtTokenPort {
 
     private final Map<String, TokenPayload> tokens = new HashMap<>();
-    private final Set<String> invalidatedTokens = new HashSet<>();
 
     @Override
     public String generateAccessToken(User user) {
         String jti = UUID.randomUUID().toString();
         String token = "fake-access-token-" + jti;
-        tokens.put(token, new TokenPayload(user.getId(), user.getEmail().getValue(), jti));
+        Instant expiresAt = Instant.now().plusSeconds(900L);
+        tokens.put(token, new TokenPayload(user.getId(), user.getEmail().getValue(), jti, expiresAt));
         return token;
     }
 
@@ -22,7 +24,7 @@ public class FakeJwtTokenAdapter implements JwtTokenPort {
     public String extractJti(String accessToken) {
         TokenPayload payload = tokens.get(accessToken);
         if (payload == null) {
-            throw new IllegalArgumentException("Token inconnu : " + accessToken);
+            throw new InvalidTokenException();
         }
         return payload.jti();
     }
@@ -31,19 +33,23 @@ public class FakeJwtTokenAdapter implements JwtTokenPort {
     public UUID extractUserId(String accessToken) {
         TokenPayload payload = tokens.get(accessToken);
         if (payload == null) {
-            throw new IllegalArgumentException("Token inconnu : " + accessToken);
+            throw new InvalidTokenException();
         }
         return payload.userId();
     }
 
     @Override
     public boolean isValid(String accessToken) {
-        return tokens.containsKey(accessToken) && !invalidatedTokens.contains(accessToken);
+        return tokens.containsKey(accessToken) && tokens.get(accessToken).expiresAt().isAfter(Instant.now());
     }
 
-    public void invalidate(String accessToken) {
-        invalidatedTokens.add(accessToken);
+    @Override
+    public long getRemainingTtlSeconds(String accessToken) {
+        if (!tokens.containsKey(accessToken)) {
+            throw new InvalidTokenException();
+        }
+        return 900L;
     }
 
-    private record TokenPayload(UUID userId, String email, String jti) {}
+    private record TokenPayload(UUID userId, String email, String jti, Instant expiresAt) {}
 }

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/FakeRedisBlackListAdapter.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/FakeRedisBlackListAdapter.java
@@ -1,0 +1,34 @@
+package io.ketherlabs.postflow.identity;
+
+import io.ketherlabs.postflow.identity.domain.port.RedisBlacklistPort;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Fake adapter de blacklist Redis pour les tests unitaires.
+ * Stocke les jti en memoire via une Map (jti -> ttlSeconds).
+ * Aucune dependance Redis.
+ */
+public class FakeRedisBlackListAdapter implements RedisBlacklistPort {
+
+    private final Map<String, Long> blacklistedTokens = new HashMap<>();
+
+    @Override
+    public void blacklist(String jti, long ttlSeconds) {
+        blacklistedTokens.put(jti, ttlSeconds);
+    }
+
+    @Override
+    public boolean isBlacklisted(String jti) {
+        return blacklistedTokens.containsKey(jti);
+    }
+
+    public long getTtlSeconds(String jti) {
+        return blacklistedTokens.getOrDefault(jti, 0L);
+    }
+
+    public int size() {
+        return blacklistedTokens.size();
+    }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/FakeRefreshTokenAdapter.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/FakeRefreshTokenAdapter.java
@@ -1,0 +1,16 @@
+package io.ketherlabs.postflow.identity;
+
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.port.RefreshTokenPort;
+
+public class FakeRefreshTokenAdapter implements RefreshTokenPort {
+    @Override
+    public String generateRefreshToken(User user) {
+        return "fake-refresh-token-for-user-" + user.getId();
+    }
+
+    @Override
+    public boolean isValid(String tokenHash) {
+        return tokenHash != null && !tokenHash.isBlank();
+    }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/LoginUseCaseTest.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/LoginUseCaseTest.java
@@ -1,0 +1,315 @@
+package io.ketherlabs.postflow.identity;
+
+import io.ketherlabs.postflow.identity.domain.entity.RefreshToken;
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.entity.valueobject.Email;
+import io.ketherlabs.postflow.identity.domain.entity.valueobject.Password;
+import io.ketherlabs.postflow.identity.domain.exception.AccountNotVerifiedException;
+import io.ketherlabs.postflow.identity.domain.exception.AccountSuspendedException;
+import io.ketherlabs.postflow.identity.domain.exception.InvalidCredentialsException;
+import io.ketherlabs.postflow.identity.domain.usecase.LoginUseCase;
+import io.ketherlabs.postflow.identity.domain.usecase.input.LoginCommand;
+import io.ketherlabs.postflow.identity.domain.usecase.output.LoginResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Tests unitaires du UseCase {@link LoginUseCase}.
+ * Valide l'ensemble du processus de connexion : authentification,
+ * generation des tokens, persistance du refresh token et mise a jour du lastLogin.
+ */
+
+class LoginUseCaseTest {
+
+    private FakeUserRepository fakeUserRepo;
+    private FakeJwtTokenAdapter fakeJwtTokenAdapter;
+    private FakeRefreshTokenRepository fakeRefreshTokenRepo;
+    private FakeRefreshTokenAdapter fakeRefreshTokenAdapter;
+    private FakePasswordEncoderAdapter fakePasswordEncoder;
+    private LoginUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        fakeUserRepo = new FakeUserRepository();
+        fakeJwtTokenAdapter = new FakeJwtTokenAdapter();
+        fakeRefreshTokenRepo = new FakeRefreshTokenRepository();
+        fakeRefreshTokenAdapter = new FakeRefreshTokenAdapter();
+        fakePasswordEncoder = new FakePasswordEncoderAdapter();
+        useCase = new LoginUseCase(
+                fakeUserRepo,
+                fakeJwtTokenAdapter,
+                fakeRefreshTokenRepo,
+                fakeRefreshTokenAdapter,
+                fakePasswordEncoder
+        );
+    }
+
+    private LoginCommand validCommand() {
+        return new LoginCommand("john@example.com", "securePassword123");
+    }
+
+    /**
+     * Cree un utilisateur ACTIVE avec le mot de passe hashe via le FakePasswordEncoder.
+     */
+    private User registerAndActivateUser() {
+        User user = User.register(
+                "John",
+                "Doe",
+                Email.of("john@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("securePassword123"))
+        );
+        user.activate();
+        fakeUserRepo.register(user);
+        return user;
+    }
+
+    /**
+     * Cree un utilisateur PENDING_VERIFICATION (non active).
+     */
+    private void registerPendingUser() {
+        User user = User.register(
+                "John",
+                "Doe",
+                Email.of("john@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("securePassword123"))
+        );
+        fakeUserRepo.register(user);
+    }
+
+    /**
+     * Cree un utilisateur SUSPENDED.
+     */
+    private void registerSuspendedUser() {
+        User user = User.register(
+                "John",
+                "Doe",
+                Email.of("john@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("securePassword123"))
+        );
+        user.activate();
+        user.suspend();
+        fakeUserRepo.register(user);
+    }
+
+    // =====================================================
+    // 1. Test de reponse : access token et refresh token
+    // =====================================================
+
+    @Test
+    void should_return_response_with_access_and_refresh_tokens() {
+        registerAndActivateUser();
+
+        LoginResponse response = useCase.execute(validCommand());
+
+        assertNotNull(response.accessToken());
+        assertNotNull(response.refreshToken());
+        assertFalse(response.accessToken().isBlank());
+        assertFalse(response.refreshToken().isBlank());
+    }
+
+    // =====================================================
+    // 2. Test d'exception : email inconnu
+    // =====================================================
+
+    @Test
+    void should_throw_invalid_credentials_when_email_not_found() {
+        // Aucun utilisateur enregistre
+
+        assertThrows(
+                InvalidCredentialsException.class,
+                () -> useCase.execute(validCommand())
+        );
+    }
+
+    @Test
+    void should_throw_invalid_credentials_with_correct_message_when_email_not_found() {
+        InvalidCredentialsException ex = assertThrows(
+                InvalidCredentialsException.class,
+                () -> useCase.execute(validCommand())
+        );
+        assertTrue(ex.getMessage().contains("Invalid email or password"));
+    }
+
+    // =====================================================
+    // 3. Test d'exception : compte non verifie
+    // =====================================================
+
+    @Test
+    void should_throw_exception_when_account_is_pending_verification() {
+        registerPendingUser();
+
+        assertThrows(
+                AccountNotVerifiedException.class,
+                () -> useCase.execute(validCommand())
+        );
+    }
+
+    // =====================================================
+    // 4. Test d'exception : compte suspendu
+    // =====================================================
+
+    @Test
+    void should_throw_exception_when_account_is_suspended() {
+        registerSuspendedUser();
+
+        assertThrows(
+                AccountSuspendedException.class,
+                () -> useCase.execute(validCommand())
+        );
+    }
+
+    // =====================================================
+    // 5. Test d'exception : mot de passe incorrect
+    // =====================================================
+
+    @Test
+    void should_throw_invalid_credentials_when_password_is_wrong() {
+        registerAndActivateUser();
+
+        LoginCommand wrongPasswordCmd = new LoginCommand("john@example.com", "wrongPassword123");
+
+        assertThrows(
+                InvalidCredentialsException.class,
+                () -> useCase.execute(wrongPasswordCmd)
+        );
+    }
+
+    @Test
+    void should_not_generate_tokens_when_password_is_wrong() {
+        registerAndActivateUser();
+
+        LoginCommand wrongPasswordCmd = new LoginCommand("john@example.com", "wrongPassword123");
+
+        assertThrows(InvalidCredentialsException.class, () -> useCase.execute(wrongPasswordCmd));
+
+        // Aucun refresh token ne doit etre persiste
+        User user = fakeUserRepo.findByEmail("john@example.com").orElseThrow();
+        assertEquals(0, fakeRefreshTokenRepo.countActiveByUserId(user.getId()));
+    }
+
+    // =====================================================
+    // 6. Test de generation du JWT access token
+    // =====================================================
+
+    @Test
+    void should_generate_access_token_for_user() {
+        registerAndActivateUser();
+
+        LoginResponse response = useCase.execute(validCommand());
+
+        assertTrue(response.accessToken().startsWith("fake-access-token-"));
+    }
+
+    @Test
+    void should_generate_valid_access_token() {
+        registerAndActivateUser();
+
+        LoginResponse response = useCase.execute(validCommand());
+
+        assertTrue(fakeJwtTokenAdapter.isValid(response.accessToken()));
+    }
+
+    // =====================================================
+    // 7. Test de generation et persistance du refresh token
+    // =====================================================
+
+    @Test
+    void should_generate_refresh_token() {
+        registerAndActivateUser();
+
+        LoginResponse response = useCase.execute(validCommand());
+
+        assertNotNull(response.refreshToken());
+        assertTrue(response.refreshToken().startsWith("fake-refresh-token-for-user-"));
+    }
+
+    @Test
+    void should_persist_refresh_token_in_repository() {
+        User user = registerAndActivateUser();
+
+        useCase.execute(validCommand());
+
+        assertEquals(1, fakeRefreshTokenRepo.countActiveByUserId(user.getId()));
+    }
+
+    @Test
+    void should_persist_hashed_refresh_token() {
+        registerAndActivateUser();
+
+        LoginResponse response = useCase.execute(validCommand());
+
+        // Le token persisté est le hash du raw token, pas le raw token lui-meme
+        String expectedHash = fakePasswordEncoder.encode(response.refreshToken());
+        assertTrue(fakeRefreshTokenRepo.findByTokenHash(expectedHash).isPresent());
+    }
+
+    @Test
+    void should_create_non_revoked_refresh_token() {
+        registerAndActivateUser();
+
+        LoginResponse response = useCase.execute(validCommand());
+
+        String tokenHash = fakePasswordEncoder.encode(response.refreshToken());
+        RefreshToken refreshToken = fakeRefreshTokenRepo.findByTokenHash(tokenHash).orElseThrow();
+        assertFalse(refreshToken.isRevoked());
+        assertTrue(refreshToken.isValid());
+    }
+
+    @Test
+    void should_link_refresh_token_to_correct_user() {
+        User user = registerAndActivateUser();
+
+        LoginResponse response = useCase.execute(validCommand());
+
+        String tokenHash = fakePasswordEncoder.encode(response.refreshToken());
+        RefreshToken refreshToken = fakeRefreshTokenRepo.findByTokenHash(tokenHash).orElseThrow();
+        assertEquals(user.getId(), refreshToken.getUserId());
+    }
+
+    // =====================================================
+    // 8. Test de mise a jour de la derniere connexion
+    // =====================================================
+
+    @Test
+    void should_update_last_login_date() {
+        User user = registerAndActivateUser();
+        assertNull(user.getLastLoginAt());
+
+        useCase.execute(validCommand());
+
+        User updated = fakeUserRepo.findByEmail("john@example.com").orElseThrow();
+        assertNotNull(updated.getLastLoginAt());
+    }
+
+    // =====================================================
+    // 9. Test de validation de la commande LoginCommand
+    // =====================================================
+
+    @Test
+    void should_throw_when_email_is_null() {
+        assertThrows(IllegalArgumentException.class, () -> new LoginCommand(null, "password123"));
+    }
+
+    @Test
+    void should_throw_when_email_is_blank() {
+        assertThrows(IllegalArgumentException.class, () -> new LoginCommand("  ", "password123"));
+    }
+
+    @Test
+    void should_throw_when_email_format_is_invalid() {
+        assertThrows(IllegalArgumentException.class, () -> new LoginCommand("invalid-email", "password123"));
+    }
+
+    @Test
+    void should_throw_when_password_is_null() {
+        assertThrows(IllegalArgumentException.class, () -> new LoginCommand("john@example.com", null));
+    }
+
+    @Test
+    void should_throw_when_password_is_blank() {
+        assertThrows(IllegalArgumentException.class, () -> new LoginCommand("john@example.com", "  "));
+    }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/LogoutUseCaseTest.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/LogoutUseCaseTest.java
@@ -1,0 +1,282 @@
+package io.ketherlabs.postflow.identity;
+
+import io.ketherlabs.postflow.identity.domain.entity.RefreshToken;
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.entity.valueobject.Email;
+import io.ketherlabs.postflow.identity.domain.entity.valueobject.Password;
+import io.ketherlabs.postflow.identity.domain.exception.InvalidTokenException;
+import io.ketherlabs.postflow.identity.domain.usecase.LogoutUseCase;
+import io.ketherlabs.postflow.identity.domain.usecase.input.LogoutCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests unitaires du UseCase {@link LogoutUseCase}.
+ * Valide l'ensemble du processus de deconnexion :
+ * blacklist de l'access token dans Redis et revocation du refresh token de la session courante.
+ */
+class LogoutUseCaseTest {
+
+    private FakeUserRepository fakeUserRepo;
+    private FakeJwtTokenAdapter fakeJwtTokenAdapter;
+    private FakeRefreshTokenRepository fakeRefreshTokenRepo;
+    private FakeRefreshTokenAdapter fakeRefreshTokenAdapter;
+    private FakePasswordEncoderAdapter fakePasswordEncoder;
+    private FakeRedisBlackListAdapter fakeRedisBlackList;
+    private LogoutUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        fakeUserRepo = new FakeUserRepository();
+        fakeJwtTokenAdapter = new FakeJwtTokenAdapter();
+        fakeRefreshTokenRepo = new FakeRefreshTokenRepository();
+        fakeRefreshTokenAdapter = new FakeRefreshTokenAdapter();
+        fakePasswordEncoder = new FakePasswordEncoderAdapter();
+        fakeRedisBlackList = new FakeRedisBlackListAdapter();
+        useCase = new LogoutUseCase(
+                fakeRefreshTokenRepo,
+                fakeJwtTokenAdapter,
+                fakeRedisBlackList,
+                fakePasswordEncoder
+        );
+    }
+
+    /**
+     * Cree un utilisateur ACTIVE et enregistre son refresh token dans le repository.
+     * Retourne une session prete a deconnecter (accessToken + refreshToken).
+     */
+    private Session createActiveSession() {
+        User user = User.register(
+                "John",
+                "Doe",
+                Email.of("john@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("securePassword123"))
+        );
+        user.activate();
+        fakeUserRepo.register(user);
+
+        String accessToken = fakeJwtTokenAdapter.generateAccessToken(user);
+        String refreshToken = fakeRefreshTokenAdapter.generateRefreshToken(user);
+
+        String refreshTokenHash = fakePasswordEncoder.encode(refreshToken);
+        RefreshToken refreshTokenEntity = RefreshToken.create(
+                refreshTokenHash,
+                Instant.now().plusSeconds(7 * 24 * 3600),
+                user.getId()
+        );
+        fakeRefreshTokenRepo.save(refreshTokenEntity);
+
+        return new Session(user, accessToken, refreshToken, refreshTokenHash);
+    }
+
+    private record Session(User user, String accessToken, String refreshToken, String refreshTokenHash) {}
+
+    // =====================================================
+    // 1. Test du happy path : blacklist + revocation
+    // =====================================================
+
+    @Test
+    void should_blacklist_access_token_jti() {
+        Session session = createActiveSession();
+        String jti = fakeJwtTokenAdapter.extractJti(session.accessToken());
+
+        useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()));
+
+        assertTrue(fakeRedisBlackList.isBlacklisted(jti));
+    }
+
+    @Test
+    void should_blacklist_with_remaining_ttl_of_access_token() {
+        Session session = createActiveSession();
+        String jti = fakeJwtTokenAdapter.extractJti(session.accessToken());
+        long expectedTtl = fakeJwtTokenAdapter.getRemainingTtlSeconds(session.accessToken());
+
+        useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()));
+
+        assertEquals(expectedTtl, fakeRedisBlackList.getTtlSeconds(jti));
+    }
+
+    @Test
+    void should_revoke_refresh_token() {
+        Session session = createActiveSession();
+
+        useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()));
+
+        RefreshToken stored = fakeRefreshTokenRepo.findByTokenHash(session.refreshTokenHash()).orElseThrow();
+        assertTrue(stored.isRevoked());
+    }
+
+    @Test
+    void should_decrease_active_refresh_token_count_after_logout() {
+        Session session = createActiveSession();
+        assertEquals(1, fakeRefreshTokenRepo.countActiveByUserId(session.user().getId()));
+
+        useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()));
+
+        assertEquals(0, fakeRefreshTokenRepo.countActiveByUserId(session.user().getId()));
+    }
+
+    // =====================================================
+    // 2. Test d'isolation : autres sessions non affectees
+    // =====================================================
+
+    @Test
+    void should_not_revoke_refresh_tokens_of_other_users() {
+        Session session = createActiveSession();
+
+        User otherUser = User.register(
+                "Jane",
+                "Doe",
+                Email.of("jane@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("otherPassword123"))
+        );
+        otherUser.activate();
+        fakeUserRepo.register(otherUser);
+        String otherRefreshToken = fakeRefreshTokenAdapter.generateRefreshToken(otherUser);
+        RefreshToken otherEntity = RefreshToken.create(
+                fakePasswordEncoder.encode(otherRefreshToken),
+                Instant.now().plusSeconds(7 * 24 * 3600),
+                otherUser.getId()
+        );
+        fakeRefreshTokenRepo.save(otherEntity);
+
+        useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()));
+
+        assertEquals(1, fakeRefreshTokenRepo.countActiveByUserId(otherUser.getId()));
+    }
+
+    @Test
+    void should_not_blacklist_other_users_jti() {
+        Session session = createActiveSession();
+
+        User otherUser = User.register(
+                "Jane",
+                "Doe",
+                Email.of("jane@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("otherPassword123"))
+        );
+        otherUser.activate();
+        fakeUserRepo.register(otherUser);
+        String otherAccessToken = fakeJwtTokenAdapter.generateAccessToken(otherUser);
+        String otherJti = fakeJwtTokenAdapter.extractJti(otherAccessToken);
+
+        useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()));
+
+        assertFalse(fakeRedisBlackList.isBlacklisted(otherJti));
+    }
+
+    // =====================================================
+    // 3. Test d'Edge case : refresh token inconnu
+    // =====================================================
+
+    @Test
+    void should_not_throw_when_refresh_token_is_not_in_repository() {
+        User user = User.register(
+                "John",
+                "Doe",
+                Email.of("john@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("securePassword123"))
+        );
+        user.activate();
+        fakeUserRepo.register(user);
+
+        String accessToken = fakeJwtTokenAdapter.generateAccessToken(user);
+        String unknownRefreshToken = fakeRefreshTokenAdapter.generateRefreshToken(user);
+        // Aucune entite RefreshToken persistee
+
+        assertDoesNotThrow(() -> useCase.execute(new LogoutCommand(accessToken, unknownRefreshToken)));
+    }
+
+    @Test
+    void should_still_blacklist_access_token_when_refresh_token_is_unknown() {
+        User user = User.register(
+                "John",
+                "Doe",
+                Email.of("john@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("securePassword123"))
+        );
+        user.activate();
+        fakeUserRepo.register(user);
+
+        String accessToken = fakeJwtTokenAdapter.generateAccessToken(user);
+        String jti = fakeJwtTokenAdapter.extractJti(accessToken);
+        String unknownRefreshToken = fakeRefreshTokenAdapter.generateRefreshToken(user);
+
+        useCase.execute(new LogoutCommand(accessToken, unknownRefreshToken));
+
+        assertTrue(fakeRedisBlackList.isBlacklisted(jti));
+    }
+
+    // =====================================================
+    // 4. Test d'exception : access token inconnu
+    // =====================================================
+
+    @Test
+    void should_throw_when_access_token_is_unknown() {
+        Session session = createActiveSession();
+
+        LogoutCommand command = new LogoutCommand("unknown-access-token", session.refreshToken());
+
+        assertThrows(
+                InvalidTokenException.class,
+                () -> useCase.execute(command)
+        );
+    }
+
+    // =====================================================
+    // 5. Test de validation de la commande LogoutCommand
+    // =====================================================
+
+    @Test
+    void should_throw_when_access_token_is_null() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new LogoutCommand(null, "some-refresh-token")
+        );
+    }
+
+    @Test
+    void should_throw_when_access_token_is_blank() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new LogoutCommand("  ", "some-refresh-token")
+        );
+    }
+
+    @Test
+    void should_throw_when_refresh_token_is_null() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new LogoutCommand("some-access-token", null)
+        );
+    }
+
+    @Test
+    void should_throw_when_refresh_token_is_blank() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new LogoutCommand("some-access-token", "  ")
+        );
+    }
+
+    // =====================================================
+    // 6. Test idempotence : re-logout apres revocation
+    // =====================================================
+
+    @Test
+    void should_throw_when_refresh_token_is_already_revoked() {
+        Session session = createActiveSession();
+
+        useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()));
+
+        // Un second logout doit échouer car RefreshToken.revoke() refuse la double revocation
+        assertThrows(
+                IllegalStateException.class,
+                () -> useCase.execute(new LogoutCommand(session.accessToken(), session.refreshToken()))
+        );
+    }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/RefreshTokenUseCaseTest.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/RefreshTokenUseCaseTest.java
@@ -1,0 +1,325 @@
+package io.ketherlabs.postflow.identity;
+
+import io.ketherlabs.postflow.identity.domain.entity.RefreshToken;
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.entity.valueobject.Email;
+import io.ketherlabs.postflow.identity.domain.entity.valueobject.Password;
+import io.ketherlabs.postflow.identity.domain.exception.InvalidRefreshTokenException;
+import io.ketherlabs.postflow.identity.domain.exception.RefreshTokenExpiredException;
+import io.ketherlabs.postflow.identity.domain.exception.RefreshTokenRevokedException;
+import io.ketherlabs.postflow.identity.domain.usecase.RefreshTokenUseCase;
+import io.ketherlabs.postflow.identity.domain.usecase.output.LoginResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Tests unitaires du UseCase {@link RefreshTokenUseCase}.
+ * Valide l'ensemble du processus de rotation : validation du token,
+ * verification TTL/revocation, revocation de l'ancien token,
+ * generation et persistance d'un nouveau couple access + refresh token.
+ */
+
+class RefreshTokenUseCaseTest {
+
+    private FakeUserRepository fakeUserRepo;
+    private FakeJwtTokenAdapter fakeJwtTokenAdapter;
+    private FakeRefreshTokenRepository fakeRefreshTokenRepo;
+    private FakeRefreshTokenAdapter fakeRefreshTokenAdapter;
+    private FakePasswordEncoderAdapter fakePasswordEncoder;
+    private RefreshTokenUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        fakeUserRepo = new FakeUserRepository();
+        fakeJwtTokenAdapter = new FakeJwtTokenAdapter();
+        fakeRefreshTokenRepo = new FakeRefreshTokenRepository();
+        fakeRefreshTokenAdapter = new FakeRefreshTokenAdapter();
+        fakePasswordEncoder = new FakePasswordEncoderAdapter();
+        useCase = new RefreshTokenUseCase(
+                fakeRefreshTokenRepo,
+                fakeJwtTokenAdapter,
+                fakeUserRepo,
+                fakeRefreshTokenAdapter,
+                fakePasswordEncoder
+        );
+    }
+
+    /**
+     * Cree un utilisateur ACTIVE et le persiste.
+     */
+    private User registerAndActivateUser() {
+        User user = User.register(
+                "John",
+                "Doe",
+                Email.of("john@example.com"),
+                Password.fromHash(fakePasswordEncoder.encode("securePassword123"))
+        );
+        user.activate();
+        fakeUserRepo.register(user);
+        return user;
+    }
+
+    /**
+     * Persiste un refresh token hashé pour un utilisateur avec un TTL donne.
+     */
+    private RefreshToken persistRefreshToken(User user, String rawToken, Instant expiresAt) {
+        RefreshToken token = RefreshToken.create(
+                fakePasswordEncoder.encode(rawToken),
+                expiresAt,
+                user.getId()
+        );
+        fakeRefreshTokenRepo.save(token);
+        return token;
+    }
+
+    /**
+     * Persiste un refresh token revoque pour un utilisateur.
+     */
+    private void persistRevokedRefreshToken(User user, String rawToken) {
+        RefreshToken token = persistRefreshToken(user, rawToken, Instant.now().plusSeconds(3600));
+        token.markAsRevoke();
+    }
+
+    // =====================================================
+    // 1. Test de reponse : nouveau access token et nouveau refresh token
+    // =====================================================
+
+    @Test
+    void should_return_response_with_new_access_and_refresh_tokens() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        LoginResponse response = useCase.execute("raw-old-token");
+
+        assertNotNull(response.accessToken());
+        assertNotNull(response.refreshToken());
+        assertFalse(response.accessToken().isBlank());
+        assertFalse(response.refreshToken().isBlank());
+    }
+
+    // =====================================================
+    // 2. Test de validation : token null ou vide
+    // =====================================================
+
+    @Test
+    void should_throw_illegal_argument_when_token_is_null() {
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(null));
+    }
+
+    @Test
+    void should_throw_illegal_argument_when_token_is_blank() {
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute("  "));
+    }
+
+    @Test
+    void should_throw_illegal_argument_when_token_is_empty() {
+        assertThrows(IllegalArgumentException.class, () -> useCase.execute(""));
+    }
+
+    // =====================================================
+    // 3. Test d'exception : token introuvable
+    // =====================================================
+
+    @Test
+    void should_throw_invalid_refresh_token_when_token_not_found() {
+        assertThrows(
+                InvalidRefreshTokenException.class,
+                () -> useCase.execute("unknown-token")
+        );
+    }
+
+    @Test
+    void should_throw_invalid_refresh_token_with_correct_message_when_token_not_found() {
+        InvalidRefreshTokenException ex = assertThrows(
+                InvalidRefreshTokenException.class,
+                () -> useCase.execute("unknown-token")
+        );
+        assertTrue(ex.getMessage().contains("Invalid refresh token:"));
+    }
+
+    // =====================================================
+    // 4. Test d'exception : token expiré
+    // =====================================================
+
+    @Test
+    void should_throw_expired_exception_when_token_is_expired() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-expired-token", Instant.now().minusSeconds(1));
+
+        assertThrows(
+                RefreshTokenExpiredException.class,
+                () -> useCase.execute("raw-expired-token")
+        );
+    }
+
+    // =====================================================
+    // 5. Test d'exception : token deja révoqué
+    // =====================================================
+
+    @Test
+    void should_throw_revoked_exception_when_token_is_revoked() {
+        User user = registerAndActivateUser();
+        persistRevokedRefreshToken(user, "raw-revoked-token");
+
+        assertThrows(
+                RefreshTokenRevokedException.class,
+                () -> useCase.execute("raw-revoked-token")
+        );
+    }
+
+    // =====================================================
+    // 6. Test d'exception : utilisateur introuvable
+    // =====================================================
+
+    @Test
+    void should_throw_invalid_refresh_token_when_user_not_found() {
+        // Token persiste mais l'utilisateur associe n'existe pas
+        RefreshToken orphanToken = RefreshToken.create(
+                fakePasswordEncoder.encode("raw-orphan-token"),
+                Instant.now().plusSeconds(3600),
+                UUID.randomUUID()
+        );
+        fakeRefreshTokenRepo.save(orphanToken);
+
+        assertThrows(
+                InvalidRefreshTokenException.class,
+                () -> useCase.execute("raw-orphan-token")
+        );
+    }
+
+    // =====================================================
+    // 7. Test de rotation : ancien token révoqué
+    // =====================================================
+
+    @Test
+    void should_revoke_old_refresh_token_after_rotation() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        useCase.execute("raw-old-token");
+
+        String oldHash = fakePasswordEncoder.encode("raw-old-token");
+        RefreshToken oldToken = fakeRefreshTokenRepo.findByTokenHash(oldHash).orElseThrow();
+        assertTrue(oldToken.isRevoked());
+    }
+
+    // =====================================================
+    // 8. Test de generation du nouveau JWT access token
+    // =====================================================
+
+    @Test
+    void should_generate_new_access_token() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        LoginResponse response = useCase.execute("raw-old-token");
+
+        assertTrue(response.accessToken().startsWith("fake-access-token-"));
+    }
+
+    @Test
+    void should_generate_valid_new_access_token() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        LoginResponse response = useCase.execute("raw-old-token");
+
+        assertTrue(fakeJwtTokenAdapter.isValid(response.accessToken()));
+    }
+
+    // =====================================================
+    // 9. Test de generation et persistance du nouveau refresh token
+    // =====================================================
+
+    @Test
+    void should_generate_new_refresh_token_distinct_from_old() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        LoginResponse response = useCase.execute("raw-old-token");
+
+        assertNotEquals("raw-old-token", response.refreshToken());
+        assertTrue(response.refreshToken().startsWith("fake-refresh-token-for-user-"));
+    }
+
+    @Test
+    void should_persist_new_hashed_refresh_token() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        LoginResponse response = useCase.execute("raw-old-token");
+
+        // Le token persiste est le hash du raw token retourné, pas le raw token lui-meme
+        String expectedHash = fakePasswordEncoder.encode(response.refreshToken());
+        assertTrue(fakeRefreshTokenRepo.findByTokenHash(expectedHash).isPresent());
+    }
+
+    @Test
+    void should_create_non_revoked_new_refresh_token() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        LoginResponse response = useCase.execute("raw-old-token");
+
+        String newHash = fakePasswordEncoder.encode(response.refreshToken());
+        RefreshToken newToken = fakeRefreshTokenRepo.findByTokenHash(newHash).orElseThrow();
+        assertFalse(newToken.isRevoked());
+        assertTrue(newToken.isValid());
+    }
+
+    @Test
+    void should_link_new_refresh_token_to_correct_user() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-old-token", Instant.now().plusSeconds(3600));
+
+        LoginResponse response = useCase.execute("raw-old-token");
+
+        String newHash = fakePasswordEncoder.encode(response.refreshToken());
+        RefreshToken newToken = fakeRefreshTokenRepo.findByTokenHash(newHash).orElseThrow();
+        assertEquals(user.getId(), newToken.getUserId());
+    }
+
+    // =====================================================
+    // 10. Test : pas de nouveau token persiste sur chemin d'erreur
+    // =====================================================
+
+    @Test
+    void should_not_persist_new_token_when_token_not_found() {
+        User user = registerAndActivateUser();
+
+        assertThrows(InvalidRefreshTokenException.class, () -> useCase.execute("unknown-token"));
+
+        assertEquals(0, fakeRefreshTokenRepo.countActiveByUserId(user.getId()));
+    }
+
+    @Test
+    void should_not_persist_new_token_when_existing_is_expired() {
+        User user = registerAndActivateUser();
+        persistRefreshToken(user, "raw-expired-token", Instant.now().minusSeconds(1));
+
+        assertThrows(RefreshTokenExpiredException.class, () -> useCase.execute("raw-expired-token"));
+
+        // Hash du nouveau token qui aurait ete genere — ne doit pas exister en base
+        String newRawToken = "fake-refresh-token-for-user-" + user.getId();
+        String newHash = fakePasswordEncoder.encode(newRawToken);
+        assertTrue(fakeRefreshTokenRepo.findByTokenHash(newHash).isEmpty());
+    }
+
+    @Test
+    void should_not_persist_new_token_when_existing_is_revoked() {
+        User user = registerAndActivateUser();
+        persistRevokedRefreshToken(user, "raw-revoked-token");
+
+        assertThrows(RefreshTokenRevokedException.class, () -> useCase.execute("raw-revoked-token"));
+
+        String newRawToken = "fake-refresh-token-for-user-" + user.getId();
+        String newHash = fakePasswordEncoder.encode(newRawToken);
+        assertTrue(fakeRefreshTokenRepo.findByTokenHash(newHash).isEmpty());
+    }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/RefreshTokenUseCaseTest.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/RefreshTokenUseCaseTest.java
@@ -140,7 +140,7 @@ class RefreshTokenUseCaseTest {
                 InvalidRefreshTokenException.class,
                 () -> useCase.execute("unknown-token")
         );
-        assertTrue(ex.getMessage().contains("Invalid refresh token:"));
+        assertTrue(ex.getMessage().contains("Invalid refresh token"));
     }
 
     // =====================================================

--- a/backend/src/test/java/io/ketherlabs/postflow/identity/RegisterUseCaseTest.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/identity/RegisterUseCaseTest.java
@@ -11,7 +11,6 @@ import io.ketherlabs.postflow.identity.domain.usecase.output.RegisterResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +28,7 @@ class RegisterUseCaseTest {
 
     private FakeUserRepository fakeRepo;
     private FakeVerificationTokenRepository fakeVerificationTokenRepository;
+    private FakePasswordEncoderAdapter fakePasswordEncoder;
     private List<Object> publishedEvents;
     private RegisterUseCase useCase;
 
@@ -37,8 +37,9 @@ class RegisterUseCaseTest {
         fakeRepo = new FakeUserRepository();
         publishedEvents = new ArrayList<>();
         fakeVerificationTokenRepository = new FakeVerificationTokenRepository();
+        fakePasswordEncoder = new FakePasswordEncoderAdapter();
         ApplicationEventPublisher eventsPublisher = publishedEvents::add;
-        useCase = new RegisterUseCase(fakeRepo,fakeVerificationTokenRepository ,eventsPublisher);
+        useCase = new RegisterUseCase(fakeRepo, fakeVerificationTokenRepository, fakePasswordEncoder, eventsPublisher);
     }
 
     private RegisterCommand validCommand() {
@@ -88,29 +89,28 @@ class RegisterUseCaseTest {
     }
 
     // =====================================================
-    // 3. Test du hashage du mot de passe
+    // 3. Test du hashage du mot de passe (via PasswordEncoderPort)
     // =====================================================
 
     @Test
-    void should_hash_password_with_bcrypt() {
+    void should_hash_password_via_encoder_port() {
         useCase.execute(validCommand());
 
         User persisted = fakeRepo.findByEmail("john@example.com").orElseThrow();
         String hash = persisted.getPassword().getHashedValue();
 
         assertNotEquals("securePassword123", hash);
-        assertTrue(hash.startsWith("$2a$12$"));
+        assertEquals("hashed_securePassword123", hash);
     }
 
     @Test
-    void should_use_bcrypt_cost_factor_12() {
+    void should_persist_password_that_matches_via_encoder_port() {
         useCase.execute(validCommand());
 
         User persisted = fakeRepo.findByEmail("john@example.com").orElseThrow();
         String hash = persisted.getPassword().getHashedValue();
 
-        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(12);
-        assertTrue(encoder.matches("securePassword123", hash));
+        assertTrue(fakePasswordEncoder.matches("securePassword123", hash));
     }
 
     // =====================================================


### PR DESCRIPTION
## Issue liée
<!-- Utilisez "Closes #XXX" pour fermer automatiquement l'issue au merge. -->

Closes #72 

---

### Partie concernée

🟦 Backend uniquement — API / base de données / scheduler

### Module concerné

Authentification — login / register / sessions

### Le problème à résoudre

Implémenter les 3 use cases de session : connexion avec JWT, rotation du refresh token,
déconnexion

### La solution proposée

*  LoginUseCase : charger par email, vérifier status=ACTIVE, BCrypt compare
*  LoginUseCase : générer Access Token JWT RS256 (sub=userId, exp=+15min, jti=UUID)
*  LoginUseCase : générer Refresh Token opaque (UUID sécurisé), hasher, persister TTL 7j
*  LoginUseCase : UPDATE last_login_at, retourner tokens
*  RefreshTokenUseCase : charger token, vérifier TTL + revoked, rotation (invalider ancien, créer
nouveau)
*  LogoutUseCase : blacklister jti dans Redis (TTL résiduel), révoquer Refresh Token
*  InvalidCredentialsException : message identique email inconnu / MDP faux (anti-énumération)
* Tests unitaires

---

## Type de changement

- [x] `feat` — Nouvelle fonctionnalité
- [ ] `fix` — Correction de bug
- [ ] `docs` — Documentation uniquement
- [ ] `test` — Ajout ou modification de tests
- [ ] `refactor` — Refactoring sans changement de comportement
- [ ] `chore` — Maintenance, CI/CD, dépendances
- [ ] `breaking change` — Modifie l'API publique ou un contrat frontend ↔ backend

---


## Comment tester

<!-- Donnez les étapes exactes pour vérifier que ça fonctionne. -->

### 🟦 Backend
<!-- Supprimez cette section si la PR ne concerne pas le backend -->
```bash
cd backend
mvn test
mvn verify
```

---

## Checklist

### 🟦 Backend — à cocher si la PR touche au backend
- [x] `mvn test` passe sans erreur
- [x] `mvn verify` passe sans erreur (couverture JaCoCo)
- [ ] La couverture de code ne régresse pas (> 80% sur les services)
- [ ] Tous les endpoints sont correctement typés et validés (`@Valid`)
- [x] Les erreurs retournent les bons codes HTTP
- [x] Aucune credential ou secret dans le code — uniquement dans `.env`
- [x] La logique métier est dans les services — pas dans les controllers

### 📝 Documentation
- [ ] J'ai mis à jour la documentation si nécessaire
- [ ] Si un nouvel endpoint est créé — il est documenté dans `docs/api-reference.md`
- [ ] Si une variable d'environnement est ajoutée — elle est dans `.env.example`

### 🔀 Git
- [x] Ma branche est à jour avec `develop` — pas de conflits
- [x] Mes commits suivent la convention `type(frontend|backend): description`
- [x] Il n'y a pas de commits de debug ou temporaires (`console.log`, `System.out.println`)
- [x] Ma PR cible `develop` et non `main`

---

## Notes pour le reviewer

- J'ai juste fait des tests unitaires, pas de test d'integration
- J'ai ajusté RegisterUseCase pour qu'il utilise le PasswordEncoderPort
- Le LogoutUseCase ne révoque que le Refresh Token de la session courante et non toutes sessions actives de l'utilisateur
- Au niveau de l'interface JwtTokenPort j'ai ajouté la methode getRemainingTtlSeconds qui permet de retourner le temps résiduel d'un token en secondes