### PR TITLE
Spring security config + JWT authentication filter

### DIFF
--- a/backend/src/main/java/io/ketherlabs/postflow/core/domain/port/RateLimitPort.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/core/domain/port/RateLimitPort.java
@@ -1,0 +1,31 @@
+package io.ketherlabs.postflow.core.domain.port;
+
+/**
+ * Port sortant définissant le contrat de rate limiting par clé.
+ *
+ * <p>Interface pure — aucune annotation, aucun import Spring ou Redis.
+ * Implémentée par {@code RedisRateLimitAdapter} dans la couche infrastructure.
+ *
+ * <p>L'algorithme utilisé est la <b>fenêtre fixe</b> : un compteur Redis
+ * est incrémenté à chaque appel et expire automatiquement après
+ * {@code windowSeconds} secondes. Simple, efficace, adapté à une
+ * protection contre le brute-force et le scraping.
+ */
+public interface RateLimitPort {
+
+    /**
+     * Vérifie si une requête identifiée par {@code key} est autorisée
+     * dans la fenêtre de temps courante.
+     *
+     * <p>Incrémente le compteur associé à {@code key} à chaque appel.
+     * Si le compteur dépasse {@code maxRequests}, la méthode retourne
+     * {@code false} sans interrompre d'elle-même la requête — c'est
+     * à l'appelant ({@code RateLimitInterceptor}) de renvoyer le 429.
+     *
+     * @param key           clé unique identifiant la limite (ex : {@code "rate:auth:192.168.1.1"})
+     * @param maxRequests   nombre maximum de requêtes autorisées dans la fenêtre
+     * @param windowSeconds durée de la fenêtre glissante en secondes
+     * @return {@code true} si la requête est dans les limites, {@code false} sinon
+     */
+    boolean isAllowed(String key, int maxRequests, int windowSeconds);
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/ratelimit/RateLimitInterceptor.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,104 @@
+package io.ketherlabs.postflow.core.infrastructure.ratelimit;
+
+import io.ketherlabs.postflow.core.domain.port.RateLimitPort;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+/**
+ * Intercepteur Spring MVC appliquant deux niveaux de rate limiting par IP :
+ *
+ * <ul>
+ *   <li><b>Auth</b> — {@code /api/auth/**} : {@code app.rate-limit.auth.max-requests}
+ *       requêtes par minute. Protège le login/register contre le brute-force.</li>
+ *   <li><b>Global</b> — toutes les routes : {@code app.rate-limit.global.max-requests}
+ *       requêtes par minute. Protection générale contre le scraping et les abus.</li>
+ * </ul>
+ *
+ * <p>Une requête sur {@code /api/auth/**} consomme un slot dans les deux compteurs.
+ * Le limite auth (plus restrictive) est vérifiée en premier pour renvoyer
+ * le message d'erreur le plus précis.
+ *
+ * <p>L'IP est extraite du header {@code X-Forwarded-For} si présent (proxy/load
+ * balancer), sinon depuis {@code request.getRemoteAddr()}.
+ *
+ * <p>En cas de dépassement, renvoie {@code 429 Too Many Requests} avec le
+ * header {@code Retry-After: 60}.
+ */
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private static final String AUTH_PATH_PREFIX = "/api/auth/";
+    private static final int    WINDOW_SECONDS    = 60;
+
+    @Value("${app.rate-limit.global.max-requests:100}")
+    private int globalMaxRequests;
+
+    @Value("${app.rate-limit.auth.max-requests:10}")
+    private int authMaxRequests;
+
+    private final RateLimitPort rateLimitPort;
+
+    /**
+     * Vérifie les limites avant que la requête atteigne le contrôleur.
+     *
+     * @return {@code true} si la requête est autorisée, {@code false} si bloquée (429 envoyé)
+     * @throws IOException en cas d'erreur d'écriture sur la réponse
+     */
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request,
+                             @NonNull HttpServletResponse response,
+                             @NonNull Object handler) throws IOException {
+
+        String ip   = extractClientIp(request);
+        String path = request.getRequestURI();
+
+        if (path.startsWith(AUTH_PATH_PREFIX)) {
+            if (!rateLimitPort.isAllowed("rate:auth:" + ip, authMaxRequests, WINDOW_SECONDS)) {
+                sendTooManyRequests(response, "Too many authentication attempts. Try again in 1 minute.");
+                return false;
+            }
+        }
+
+        if (!rateLimitPort.isAllowed("rate:global:" + ip, globalMaxRequests, WINDOW_SECONDS)) {
+            sendTooManyRequests(response, "Too many requests. Try again in 1 minute.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Extrait l'IP réelle du client.
+     *
+     * <p>Consulte d'abord {@code X-Forwarded-For} (premier hop en cas de
+     * chaîne de proxies) avant de tomber sur {@code getRemoteAddr()}.
+     */
+    private String extractClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * Écrit une réponse {@code 429 Too Many Requests} avec le header
+     * {@code Retry-After} indiquant la durée d'attente en secondes.
+     */
+    private void sendTooManyRequests(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setHeader("Retry-After", String.valueOf(WINDOW_SECONDS));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("{\"error\":\"" + message + "\"}");
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/ratelimit/RedisRateLimitAdapter.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/ratelimit/RedisRateLimitAdapter.java
@@ -1,0 +1,54 @@
+package io.ketherlabs.postflow.core.infrastructure.ratelimit;
+
+import io.ketherlabs.postflow.core.domain.port.RateLimitPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Adaptateur sortant implémentant {@link RateLimitPort} via Redis.
+ *
+ * <p>Utilise l'algorithme de <b>fenêtre fixe</b> :
+ * <ol>
+ *   <li>{@code INCR key} — incrémente le compteur atomiquement.</li>
+ *   <li>{@code EXPIRE key windowSeconds} — positionne le TTL uniquement
+ *       à la première requête ({@code count == 1}) pour que la fenêtre
+ *       démarre au premier appel et s'efface seule.</li>
+ * </ol>
+ *
+ * <p>Réutilise le {@link StringRedisTemplate} déclaré dans
+ * {@code RedisConfig} — aucune connexion Redis supplémentaire.
+ *
+ * <p>Limite connue : entre {@code INCR} et {@code EXPIRE}, une infime
+ * fenêtre de race condition existe. En pratique, elle est négligeable pour
+ * du rate limiting; un script Lua serait nécessaire pour une atomicité totale.
+ */
+@Component
+@RequiredArgsConstructor
+public class RedisRateLimitAdapter implements RateLimitPort {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Retourne {@code false} (requête bloquée) si Redis est indisponible
+     * et que {@code increment()} renvoie {@code null} — comportement
+     * conservateur : on bloque plutôt que de laisser passer sans contrôle.
+     */
+    @Override
+    public boolean isAllowed(String key, int maxRequests, int windowSeconds) {
+        Long count = stringRedisTemplate.opsForValue().increment(key);
+
+        if (count == null) {
+            return false;
+        }
+        if (count == 1) {
+            stringRedisTemplate.expire(key, windowSeconds, TimeUnit.SECONDS);
+        }
+
+        return count <= maxRequests;
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/ratelimit/WebMvcConfig.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/ratelimit/WebMvcConfig.java
@@ -1,0 +1,31 @@
+package io.ketherlabs.postflow.core.infrastructure.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Configuration Spring MVC enregistrant les intercepteurs applicatifs.
+ *
+ * <p>Séparée de {@code SecurityConfig} car les intercepteurs Spring MVC
+ * s'exécutent après la security filter chain — ils opèrent au niveau
+ * du DispatcherServlet, pas du conteneur servlet.
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    /**
+     * Enregistre {@link RateLimitInterceptor} sur toutes les routes ({@code /**}).
+     *
+     * <p>Le filtrage auth et global est géré dans l'intercepteur lui-même
+     * en inspectant l'URI — pas besoin de deux enregistrements distincts.
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor);
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/security/JwtAuthenticationFilter.java
@@ -1,0 +1,121 @@
+package io.ketherlabs.postflow.core.infrastructure.security;
+
+import io.ketherlabs.postflow.identity.domain.port.JwtTokenPort;
+import io.ketherlabs.postflow.identity.domain.port.RedisBlacklistPort;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import org.jspecify.annotations.NonNull;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Filtre Spring Security chargé de valider le JWT Bearer à chaque requête.
+ *
+ * <p>Intercale avant {@code UsernamePasswordAuthenticationFilter} dans la
+ * security chain (voir {@link SecurityConfig}). S'exécute exactement une
+ * fois par requête grâce à {@link OncePerRequestFilter}.
+ *
+ * <p>Flux de traitement :
+ * <ol>
+ *   <li>Extraction du header {@code Authorization: Bearer <token>}.
+ *       Si absent ou mal formé, la requête est transmise sans authentification
+ *       (Spring Security gérera l'accès selon les règles d'autorisation).</li>
+ *   <li>Validation de la signature RS256 et de l'expiration via
+ *       {@link JwtTokenPort#isValid(String)} — retourne {@code 401} si invalide.</li>
+ *   <li>Vérification de la blacklist Redis via
+ *       {@link RedisBlacklistPort#isBlacklisted(String)} — retourne {@code 401}
+ *       si le token a été révoqué (logout).</li>
+ *   <li>Population du {@code SecurityContextHolder} avec l'identité de
+ *       l'utilisateur ({@code userId} extrait du claim {@code sub}).</li>
+ * </ol>
+ *
+ * <p>Dépend uniquement de ports du domaine {@code identity} — aucun import
+ * de technologie concrète (JJWT, Redis) dans ce filtre.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenPort jwtTokenPort;
+    private final RedisBlacklistPort redisBlacklistPort;
+
+    /**
+     * Point d'entrée du filtre, appelé une fois par requête HTTP.
+     *
+     * <p>Si le token est absent, le filtre délègue sans interrompre la chaîne :
+     * c'est Spring Security qui décidera si la route est publique ou non.
+     * Si le token est présent mais invalide ou révoqué, la requête est
+     * court-circuitée avec un {@code 401}.
+     *
+     * @param request     la requête HTTP entrante
+     * @param response    la réponse HTTP à compléter en cas de rejet
+     * @param filterChain la chaîne de filtres à poursuivre si le token est valide
+     * @throws ServletException en cas d'erreur de traitement servlet
+     * @throws IOException      en cas d'erreur d'écriture sur la réponse
+     */
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(BEARER_PREFIX.length());
+
+        if (!jwtTokenPort.isValid(token)) {
+            sendUnauthorized(response, "Invalid or expired token");
+            return;
+        }
+
+        String jti = jwtTokenPort.extractJti(token);
+        if (redisBlacklistPort.isBlacklisted(jti)) {
+            sendUnauthorized(response, "Token has been revoked");
+            return;
+        }
+
+        String userId = jwtTokenPort.extractUserId(token).toString();
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                userId, null, Collections.emptyList()  // Pas de roles pour l'instant
+        );
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Écrit une réponse {@code 401 Unauthorized} au format JSON et interrompt
+     * la chaîne de filtres.
+     *
+     * @param response la réponse HTTP à compléter
+     * @param message  le message d'erreur à sérialiser dans le corps JSON
+     * @throws IOException en cas d'erreur d'écriture sur le flux de sortie
+     */
+    private void sendUnauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("{\"error\":\"" + message + "\"}");
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/core/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,131 @@
+package io.ketherlabs.postflow.core.infrastructure.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+/**
+ * Configuration centrale de Spring Security pour l'ensemble de l'application.
+ *
+ * <p>Positionnée dans {@code core/infrastructure/security} car elle est
+ * transversale à tous les domaines (identity, post, billing...) — elle ne
+ * dépend d'aucun module métier et protège toutes les routes du projet.
+ *
+ * <p>Principes appliqués :
+ * <ul>
+ *   <li><b>Stateless</b> — aucune session HTTP côté serveur ; l'identité
+ *       de l'appelant est portée exclusivement par le JWT.</li>
+ *   <li><b>CSRF désactivé</b> — inutile en mode stateless (pas de cookies
+ *       de session à protéger).</li>
+ *   <li><b>CORS whitelist</b> — seule l'origine frontend déclarée dans
+ *       {@code app.cors.allowed-origins} peut consommer l'API.</li>
+ *   <li><b>Routes publiques</b> — {@code /api/auth/**} et
+ *       {@code /actuator/health} sont accessibles sans token.</li>
+ * </ul>
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private static final String[] PUBLIC_ROUTES = {
+            "/api/auth/**",
+            "/actuator/health"
+    };
+
+    @Value("${app.cors.allowed-origins}")
+    private String allowedOrigins;
+
+    /**
+     * Déclare la chaîne de filtres Spring Security.
+     *
+     * <p>Ordre d'application sur chaque requête entrante :
+     * <ol>
+     *   <li>{@link JwtAuthenticationFilter} — valide le Bearer token et
+     *       alimente le {@code SecurityContextHolder}.</li>
+     *   <li>Vérification des autorisations — routes publiques libres,
+     *       toutes les autres exigent une authentification.</li>
+     * </ol>
+     *
+     * @param http              le configurateur Spring Security fourni par le contexte
+     * @param jwtAuthenticationFilter le filtre JWT à intercaler avant l'auth classique
+     * @return la {@link SecurityFilterChain} enregistrée dans le contexte Spring
+     */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter) {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_ROUTES).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    /**
+     * Désactive l'auto-enregistrement de {@link JwtAuthenticationFilter}
+     * comme filtre servlet global par Spring Boot.
+     *
+     * <p>Tout bean qui étend {@code OncePerRequestFilter} est automatiquement
+     * enregistré par Spring Boot dans la chaîne servlet générale. Sans ce bean,
+     * le filtre s'exécuterait deux fois par requête : une fois hors de la
+     * security chain (enregistrement auto) et une fois à l'intérieur
+     * (via {@code addFilterBefore}).
+     *
+     * @param filter le filtre JWT géré par Spring
+     * @return un {@link FilterRegistrationBean} configuré pour ne pas s'enregistrer
+     */
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilterRegistration(
+            JwtAuthenticationFilter filter) {
+        FilterRegistrationBean<JwtAuthenticationFilter> registration =
+                new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+
+    /**
+     * Configure la politique CORS appliquée à toutes les routes ({@code /**}).
+     *
+     * <p>Seule l'origine déclarée dans {@code app.cors.allowed-origins}
+     * (variable d'environnement {@code FRONTEND_URL}) est autorisée.
+     * Plusieurs origines peuvent être séparées par une virgule dans la variable.
+     *
+     * <p>{@code maxAge: 3600} met en cache le résultat du preflight OPTIONS
+     * pendant une heure côté navigateur, évitant une requête OPTIONS
+     * supplémentaire à chaque appel API.
+     *
+     * @return la source de configuration CORS enregistrée dans Spring Security
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(allowedOrigins.split(",")));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/backend/src/main/java/io/ketherlabs/postflow/identity/domain/port/JwtTokenPort.java
+++ b/backend/src/main/java/io/ketherlabs/postflow/identity/domain/port/JwtTokenPort.java
@@ -1,6 +1,7 @@
 package io.ketherlabs.postflow.identity.domain.port;
 
 
+import io.ketherlabs.postflow.core.infrastructure.security.JwtAuthenticationFilter;
 import io.ketherlabs.postflow.identity.domain.entity.User;
 
 import java.util.UUID;
@@ -48,7 +49,7 @@ public interface JwtTokenPort {
      * Valide la signature RS256 et l'expiration d'un Access Token.
      *
      * <p>Ne vérifie PAS la blacklist Redis — cette vérification
-     * est faite séparément par {@code JwtAuthenticationFilter}.
+     * est faite séparément par {@link JwtAuthenticationFilter}.
      *
      * @param accessToken le JWT à valider
      * @return {@code true} si la signature est valide et le token non expiré

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -57,6 +57,13 @@ app:
   base-url: ${APP_BASE_URL}
   mail:
     from: ${MAIL_FROM}
+  cors:
+    allowed-origins: ${FRONTEND_URL:http://localhost:3000}
+  rate-limit:
+    global:
+      max-requests: ${RATE_LIMIT_GLOBAL:100}
+    auth:
+      max-requests: ${RATE_LIMIT_AUTH:10}
 jwt:
   private-key: ${JWT_PRIVATE_KEY}
   public-key: ${JWT_PUBLIC_KEY}

--- a/backend/src/test/java/io/ketherlabs/postflow/core/ratelimit/FakeRedisRateLimitAdapter.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/core/ratelimit/FakeRedisRateLimitAdapter.java
@@ -1,0 +1,29 @@
+package io.ketherlabs.postflow.core.ratelimit;
+
+import io.ketherlabs.postflow.core.domain.port.RateLimitPort;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Fake qui reproduit le comportement réel du compteur par clé Redis.
+ * Compte les appels pour chaque clé et retourne false dès que maxRequests est dépassé.
+ */
+public class FakeRedisRateLimitAdapter implements RateLimitPort {
+
+    private final Map<String, Integer> counters = new HashMap<>();
+
+    @Override
+    public boolean isAllowed(String key, int maxRequests, int windowSeconds) {
+        int count = counters.merge(key, 1, Integer::sum);
+        return count <= maxRequests;
+    }
+
+    int countCallsFor(String keyPrefix) {
+        return counters.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(keyPrefix))
+                .mapToInt(Map.Entry::getValue)
+                .sum();
+    }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/core/ratelimit/RateLimitInterceptorTest.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/core/ratelimit/RateLimitInterceptorTest.java
@@ -1,0 +1,231 @@
+package io.ketherlabs.postflow.core.ratelimit;
+
+import io.ketherlabs.postflow.core.infrastructure.ratelimit.RateLimitInterceptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimitInterceptorTest {
+
+    private static final int GLOBAL_LIMIT = 100;
+    private static final int AUTH_LIMIT   = 10;
+
+
+    // ─── Setup ───────────────────────────────────────────────────────────────
+
+    private FakeRedisRateLimitAdapter fakeRateLimit;
+    private RateLimitInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        fakeRateLimit = new FakeRedisRateLimitAdapter();
+        interceptor   = new RateLimitInterceptor(fakeRateLimit);
+        ReflectionTestUtils.setField(interceptor, "globalMaxRequests", GLOBAL_LIMIT);
+        ReflectionTestUtils.setField(interceptor, "authMaxRequests",   AUTH_LIMIT);
+    }
+
+    // ─── # Limite globale ────────────────────────────────────────────────────
+
+    @Test
+    void should_pass_when_first_request_on_any_route() throws Exception {
+        MockHttpServletRequest  request  = buildRequest("GET", "/api/posts", "10.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertTrue(result);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void should_pass_when_exactly_at_global_limit() throws Exception {
+        MockHttpServletRequest request = buildRequest("GET", "/api/posts", "10.0.0.2");
+
+        for (int i = 0; i < GLOBAL_LIMIT - 1; i++) {
+            interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+        }
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        boolean result = interceptor.preHandle(request, response, new Object()); // 100ème
+
+        assertTrue(result);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void should_return_429_when_global_limit_is_exceeded() throws Exception {
+        MockHttpServletRequest request = buildRequest("GET", "/api/posts", "10.0.0.3");
+
+        for (int i = 0; i < GLOBAL_LIMIT; i++) {
+            interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+        }
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        boolean result = interceptor.preHandle(request, response, new Object()); // 101ème
+
+        assertFalse(result);
+        assertEquals(429, response.getStatus());
+        assertTrue(response.getContentAsString().contains("Too many requests"));
+    }
+
+    @Test
+    void should_include_retry_after_header_when_global_limit_is_exceeded() throws Exception {
+        MockHttpServletRequest request = buildRequest("GET", "/api/posts", "10.0.0.4");
+
+        for (int i = 0; i < GLOBAL_LIMIT; i++) {
+            interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+        }
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        interceptor.preHandle(request, response, new Object());
+
+        assertEquals("60", response.getHeader("Retry-After"));
+    }
+
+    @Test
+    void should_not_share_counters_between_different_ips() throws Exception {
+        MockHttpServletRequest ipA = buildRequest("GET", "/api/posts", "1.1.1.1");
+        MockHttpServletRequest ipB = buildRequest("GET", "/api/posts", "2.2.2.2");
+
+        // IP A dépasse la limite
+        for (int i = 0; i < GLOBAL_LIMIT; i++) {
+            interceptor.preHandle(ipA, new MockHttpServletResponse(), new Object());
+        }
+
+        // IP B doit toujours passer
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        boolean result = interceptor.preHandle(ipB, response, new Object());
+
+        assertTrue(result, "IP B should be allowed to make requests even if IP A has exceeded the limit");
+    }
+
+    // ─── # Limite auth ───────────────────────────────────────────────────────
+
+    @Test
+    void should_pass_when_first_auth_request() throws Exception {
+        MockHttpServletRequest  request  = buildRequest("POST", "/api/auth/login", "10.0.0.5");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertTrue(result);
+    }
+
+    @Test
+    void should_return_429_when_auth_limit_is_exceeded() throws Exception {
+        MockHttpServletRequest request = buildRequest("POST", "/api/auth/login", "10.0.0.6");
+
+        for (int i = 0; i < AUTH_LIMIT; i++) {
+            interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+        }
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        boolean result = interceptor.preHandle(request, response, new Object()); // 11ème
+
+        assertFalse(result);
+        assertEquals(429, response.getStatus());
+        assertTrue(response.getContentAsString().contains("Too many authentication attempts"));
+    }
+
+    @Test
+    void should_return_auth_specific_message_when_auth_limit_is_exceeded() throws Exception {
+        // Intercepteur avec authMax=2 et globalMax=100 pour isoler le cas auth
+        RateLimitInterceptor custom = new RateLimitInterceptor(fakeRateLimit);
+        ReflectionTestUtils.setField(custom, "globalMaxRequests", 100);
+        ReflectionTestUtils.setField(custom, "authMaxRequests",   2);
+
+        MockHttpServletRequest request = buildRequest("POST", "/api/auth/login", "10.0.0.7");
+
+        custom.preHandle(request, new MockHttpServletResponse(), new Object());
+        custom.preHandle(request, new MockHttpServletResponse(), new Object());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        custom.preHandle(request, response, new Object()); // 3ème → auth bloqué
+
+        assertTrue(response.getContentAsString().contains("Too many authentication attempts"),
+                "The response should contain the auth-specific message when the auth limit is exceeded");
+    }
+
+    @Test
+    void should_return_global_message_when_auth_ok_but_global_limit_exceeded() throws Exception {
+        // authMax=100, globalMax=2 → auth passe, global bloque
+        RateLimitInterceptor custom = new RateLimitInterceptor(fakeRateLimit);
+        ReflectionTestUtils.setField(custom, "globalMaxRequests", 2);
+        ReflectionTestUtils.setField(custom, "authMaxRequests",   100);
+
+        MockHttpServletRequest request = buildRequest("POST", "/api/auth/login", "10.0.0.8");
+
+        custom.preHandle(request, new MockHttpServletResponse(), new Object());
+        custom.preHandle(request, new MockHttpServletResponse(), new Object());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        custom.preHandle(request, response, new Object()); // 3ème → global bloqué
+
+        assertFalse(custom.preHandle(request, new MockHttpServletResponse(), new Object()));
+        assertTrue(response.getContentAsString().contains("Too many requests"));
+    }
+
+    @Test
+    void should_increment_both_counters_when_auth_route_is_called() throws Exception {
+        MockHttpServletRequest request = buildRequest("POST", "/api/auth/register", "10.0.0.9");
+
+        interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertEquals(1, fakeRateLimit.countCallsFor("rate:auth:"),   "compteur auth doit être à 1");
+        assertEquals(1, fakeRateLimit.countCallsFor("rate:global:"), "compteur global doit être à 1");
+    }
+
+    @Test
+    void should_increment_only_global_counter_when_non_auth_route_is_called() throws Exception {
+        MockHttpServletRequest request = buildRequest("GET", "/api/posts", "10.0.0.10");
+
+        interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertEquals(0, fakeRateLimit.countCallsFor("rate:auth:"),   "compteur auth NE doit PAS être incrémenté");
+        assertEquals(1, fakeRateLimit.countCallsFor("rate:global:"), "compteur global doit être à 1");
+    }
+
+    // ─── # Extraction IP ─────────────────────────────────────────────────────
+
+    @Test
+    void should_use_first_ip_from_x_forwarded_for_header() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/posts");
+        request.addHeader("X-Forwarded-For", "1.2.3.4, 5.6.7.8, 9.9.9.9");
+
+        interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+        interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertEquals(2, fakeRateLimit.countCallsFor("rate:global:1.2.3.4"),
+                "l'IP réelle (premier hop) doit être utilisée pour la clé Redis");
+    }
+
+    @Test
+    void should_use_remote_addr_when_no_proxy_header() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/posts");
+        request.setRemoteAddr("192.168.1.50");
+
+        interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertEquals(1, fakeRateLimit.countCallsFor("rate:global:192.168.1.50"));
+    }
+
+    @Test
+    void should_fallback_to_remote_addr_when_x_forwarded_for_is_blank() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/posts");
+        request.addHeader("X-Forwarded-For", "   ");
+        request.setRemoteAddr("172.16.0.1");
+
+        interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertEquals(1, fakeRateLimit.countCallsFor("rate:global:172.16.0.1"));
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private MockHttpServletRequest buildRequest(String method, String uri, String remoteAddr) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, uri);
+        request.setRemoteAddr(remoteAddr);
+        return request;
+    }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/core/security/FakeJwtTokenAdapter.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/core/security/FakeJwtTokenAdapter.java
@@ -1,0 +1,22 @@
+package io.ketherlabs.postflow.core.security;
+
+import io.ketherlabs.postflow.identity.domain.entity.User;
+import io.ketherlabs.postflow.identity.domain.port.JwtTokenPort;
+
+import java.util.UUID;
+
+public class FakeJwtTokenAdapter implements JwtTokenPort {
+
+    private static final String FIXED_JTI       = "jti-test-abc-123";
+    private static final UUID FIXED_USER_ID   = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+    private boolean valid = true;
+
+    void makeInvalid() { this.valid = false; }
+
+    @Override public boolean isValid(String token)            { return valid; }
+    @Override public String  extractJti(String token)         { return FIXED_JTI; }
+    @Override public UUID extractUserId(String token)      { return FIXED_USER_ID; }
+    @Override public String  generateAccessToken(User user)   { return "fake-token"; }
+    @Override public long    getRemainingTtlSeconds(String t) { return 900L; }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/core/security/FakeRedisBlacklistAdapter.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/core/security/FakeRedisBlacklistAdapter.java
@@ -1,0 +1,16 @@
+package io.ketherlabs.postflow.core.security;
+
+import io.ketherlabs.postflow.identity.domain.port.RedisBlacklistPort;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FakeRedisBlacklistAdapter implements RedisBlacklistPort {
+
+    private final Set<String> blacklisted = new HashSet<>();
+
+    void blacklistJti(String jti) { blacklisted.add(jti); }
+
+    @Override public void    blacklist(String jti, long ttl) { blacklisted.add(jti); }
+    @Override public boolean isBlacklisted(String jti)       { return blacklisted.contains(jti); }
+}

--- a/backend/src/test/java/io/ketherlabs/postflow/core/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/io/ketherlabs/postflow/core/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,177 @@
+package io.ketherlabs.postflow.core.security;
+
+import io.ketherlabs.postflow.core.infrastructure.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String VALID_TOKEN     = "valid.header.signature";
+    private static final String INVALID_TOKEN   = "bad.token.here";
+    private static final String FIXED_JTI       = "jti-test-abc-123";
+    private static final UUID FIXED_USER_ID   = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+
+    // ─── Setup ───────────────────────────────────────────────────────────────
+
+    private FakeJwtTokenAdapter fakeJwt;
+    private FakeRedisBlacklistAdapter fakeBlacklist;
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        fakeJwt = new FakeJwtTokenAdapter();
+        fakeBlacklist = new FakeRedisBlacklistAdapter();
+        filter = new JwtAuthenticationFilter(fakeJwt, fakeBlacklist);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+
+    // ─── # Requête sans token ────────────────────────────────────────────────
+
+    @Test
+    void should_pass_through_when_no_authorization_header() throws Exception {
+        MockHttpServletRequest  request  = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain         chain    = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest(), "la chaîne doit avoir été invoquée");
+        assertEquals(200, response.getStatus());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void should_pass_through_when_basic_auth_header() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain         chain    = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest(), "Basic auth doit passer sans interférence du filtre JWT");
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    // ─── # Token invalide ────────────────────────────────────────────────────
+
+    @Test
+    void should_return_401_when_token_is_invalid() throws Exception {
+        fakeJwt.makeInvalid();
+        MockHttpServletRequest  request  = buildBearerRequest(INVALID_TOKEN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain         chain    = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(401, response.getStatus());
+        assertNull(chain.getRequest(), "la chaîne NE doit PAS être invoquée après un 401");
+    }
+
+    @Test
+    void should_return_error_message_when_token_is_invalid() throws Exception {
+        fakeJwt.makeInvalid();
+        MockHttpServletRequest  request  = buildBearerRequest(INVALID_TOKEN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertTrue(response.getContentAsString().contains("Invalid or expired token"));
+    }
+
+    @Test
+    void should_return_json_content_type_when_token_is_invalid() throws Exception {
+        fakeJwt.makeInvalid();
+        MockHttpServletRequest  request  = buildBearerRequest(INVALID_TOKEN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("application/json", response.getContentType());
+    }
+
+    // ─── # Token blacklisté ──────────────────────────────────────────────────
+
+    @Test
+    void should_return_401_when_token_is_blacklisted() throws Exception {
+        fakeBlacklist.blacklistJti(FIXED_JTI);
+        MockHttpServletRequest  request  = buildBearerRequest(VALID_TOKEN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain         chain    = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(401, response.getStatus());
+        assertNull(chain.getRequest());
+    }
+
+    @Test
+    void should_return_revoked_message_when_token_is_blacklisted() throws Exception {
+        fakeBlacklist.blacklistJti(FIXED_JTI);
+        MockHttpServletRequest  request  = buildBearerRequest(VALID_TOKEN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertTrue(response.getContentAsString().contains("Token has been revoked"));
+    }
+
+    // ─── # Token valide ──────────────────────────────────────────────────────
+
+    @Test
+    void should_pass_through_when_token_is_valid() throws Exception {
+        MockHttpServletRequest  request  = buildBearerRequest(VALID_TOKEN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain         chain    = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void should_set_authenticated_security_context_when_token_is_valid() throws Exception {
+        MockHttpServletRequest request = buildBearerRequest(VALID_TOKEN);
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth);
+        assertTrue(auth.isAuthenticated());
+    }
+
+    @Test
+    void should_set_user_id_as_principal_when_token_is_valid() throws Exception {
+        MockHttpServletRequest request = buildBearerRequest(VALID_TOKEN);
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth);
+        assertEquals(FIXED_USER_ID.toString(), auth.getPrincipal());
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private MockHttpServletRequest buildBearerRequest(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        return request;
+    }
+}


### PR DESCRIPTION
## Issue liée
<!-- Utilisez "Closes #XXX" pour fermer automatiquement l'issue au merge. -->
Closes #73 

---

### Partie concernée

🟦 Backend uniquement — API / base de données / scheduler

### Module concerné

Authentification — login / register / sessions

### Le problème à résoudre

Configurer Spring Security en mode stateless, le filtre JWT

### La solution proposée

* SecurityConfig : stateless, désactiver CSRF, CORS whitelist frontend
* JwtAuthFilter extends OncePerRequestFilter : extraire Bearer token, valider, set SecurityContext
*  Whitelist routes publiques : /api/auth/**, /actuator/health
* Rate limiting Redis sur /api/auth/** : 10 req/min/IP via intercepteur Spring (pas obligatoire pour le moment)
* Rate limiting global : 100 req/min/IP sur toutes les routes (pas obligatoire pour le moment)
* Tester que les routes protégées retournent 401 sans token valide
* Tests pour le Rate limiting

---

## Type de changement

- [x] `feat` — Nouvelle fonctionnalité
- [ ] `fix` — Correction de bug
- [ ] `docs` — Documentation uniquement
- [ ] `test` — Ajout ou modification de tests
- [ ] `refactor` — Refactoring sans changement de comportement
- [ ] `chore` — Maintenance, CI/CD, dépendances
- [ ] `breaking change` — Modifie l'API publique ou un contrat frontend ↔ backend

---


## Comment tester

<!-- Donnez les étapes exactes pour vérifier que ça fonctionne. -->

### 🟦 Backend
<!-- Supprimez cette section si la PR ne concerne pas le backend -->

```bash
cd backend
mvn test
mvn verify
```

---

## Checklist


### 🟦 Backend — à cocher si la PR touche au backend
- [x] `mvn test` passe sans erreur
- [x] `mvn verify` passe sans erreur (couverture JaCoCo)
- [x] La couverture de code ne régresse pas (> 80% sur les services)
- [ ] Tous les endpoints sont correctement typés et validés (`@Valid`)
- [x] Les erreurs retournent les bons codes HTTP
- [x] Aucune credential ou secret dans le code — uniquement dans `.env`
- [ ] La logique métier est dans les services — pas dans les controllers

### 📝 Documentation
- [ ] J'ai mis à jour la documentation si nécessaire
- [ ] Si un nouvel endpoint est créé — il est documenté dans `docs/api-reference.md`
- [ ] Si une variable d'environnement est ajoutée — elle est dans `.env.example`

### 🔀 Git
- [x] Ma branche est à jour avec `develop` — pas de conflits
- [x] Mes commits suivent la convention `type(frontend|backend): description`
- [x] Il n'y a pas de commits de debug ou temporaires (`console.log`, `System.out.println`)
- [x] Ma PR cible `develop` et non `main`

---

## Notes pour le reviewer
<!--
  Zones d'attention particulière, choix techniques à valider,
  questions ouvertes, points de compromis.
-->

- J'ai travaillé dans le dosssier `core` parceque Spring security et JwtAuthFilter n'est pas spécifique à un seul module mais concerne tous les modules du projet.